### PR TITLE
[fcl] **DRAFT** Update pop/tab to redirect if not logged in

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-08-17 -- **EXPERIMENTAL** Updates service strategies `POP/RPC` and `TAB/RPC` to use a single `window` when `authentication` is needed.
 - 2021-08-12 -- Update `pop`, `tab` onReady response to include deprecated `FCL:FRAME:READY:RESPONSE`.
 - 2021-08-10 -- Update `frame` onReady response to include deprecated `FCL:FRAME:READY:RESPONSE`.
 

--- a/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
@@ -93,7 +93,7 @@ export function execPopRPC(service, body, opts) {
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              close()
+              user.loggedIn && close()
               break
 
             case "DECLINED":

--- a/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
@@ -2,6 +2,7 @@ import {uid} from "@onflow/util-uid"
 import {pop} from "./utils/pop"
 import {normalizePollingResponse} from "../../normalize/polling-response"
 import {configLens} from "../../../default-config"
+import {coldStorage} from "../../../current-user/index"
 
 export function execPopRPC(service, body, opts) {
   return new Promise((resolve, reject) => {
@@ -54,15 +55,16 @@ export function execPopRPC(service, body, opts) {
         }
       },
 
-      onResponse(e, {close}) {
+      async onResponse(e, {close}) {
         try {
           if (typeof e.data !== "object") return
           const resp = normalizePollingResponse(e.data)
+          const user = await coldStorage.get()
 
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              close()
+              user.loggedIn && close()
               break
 
             case "DECLINED":

--- a/packages/fcl/src/current-user/exec-service/strategies/tab-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/tab-rpc.js
@@ -93,7 +93,7 @@ export function execTabRPC(service, body, opts) {
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              close()
+              user.loggedIn && close()
               break
 
             case "DECLINED":

--- a/packages/fcl/src/current-user/exec-service/strategies/tab-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/tab-rpc.js
@@ -2,6 +2,7 @@ import {uid} from "@onflow/util-uid"
 import {tab} from "./utils/tab"
 import {normalizePollingResponse} from "../../normalize/polling-response"
 import {configLens} from "../../../default-config"
+import {coldStorage} from "../../../current-user/index"
 
 export function execTabRPC(service, body, opts) {
   return new Promise((resolve, reject) => {
@@ -54,15 +55,16 @@ export function execTabRPC(service, body, opts) {
         }
       },
 
-      onResponse(e, {close}) {
+      async onResponse(e, {close}) {
         try {
           if (typeof e.data !== "object") return
           const resp = normalizePollingResponse(e.data)
+          const user = await coldStorage.get()
 
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              close()
+              user.loggedIn && close()
               break
 
             case "DECLINED":
@@ -76,7 +78,7 @@ export function execTabRPC(service, body, opts) {
               break
           }
         } catch (error) {
-          console.error("execPopRPC onResponse error", error)
+          console.error("execTabRPC onResponse error", error)
           throw error
         }
       },
@@ -105,7 +107,7 @@ export function execTabRPC(service, body, opts) {
               break
           }
         } catch (error) {
-          console.error("execPopRPC onMessage error", error)
+          console.error("execTabRPC onMessage error", error)
           throw error
         }
       },

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/render-pop.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/render-pop.js
@@ -15,9 +15,9 @@ function popupWindow(url, windowName, win, w, h) {
 
 export function renderPop(src) {
   if (popup == null || popup?.closed) {
-    popup = popupWindow(src, POP, window, 640, 600)
+    popup = popupWindow(src, POP, window, 640, 800)
   } else if (previousUrl !== src) {
-    popup = popupWindow(src, POP, window, 640, 600)
+    popup.location.replace(src)
     popup.focus()
   } else {
     popup.focus()

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/render-tab.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/render-tab.js
@@ -7,7 +7,7 @@ export function renderTab(src) {
   if (tab == null || tab?.closed) {
     tab = window.open(src, "_blank")
   } else if (previousUrl !== src) {
-    tab = window.open(src, "_blank")
+    tab.location.replace(src)
     tab.focus()
   } else {
     tab.focus()

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -25,7 +25,7 @@ const DATA = `{
   "services":[]
 }`
 
-const coldStorage = {
+export const coldStorage = {
   get: async () => {
     const fallback = JSON.parse(DATA)
     const stored = JSON.parse(sessionStorage.getItem(NAME))

--- a/packages/fcl/src/wallet-utils/on-message-from-fcl.js
+++ b/packages/fcl/src/wallet-utils/on-message-from-fcl.js
@@ -1,4 +1,4 @@
-export const onMessageFromFCL = (msg, cb = () => {}) => {
+export const onMessageFromFCL = (messageType, cb = () => {}) => {
   const buildData = data => {
     if (data.deprecated)
       console.warn("DEPRECATION NOTICE", data.deprecated.message)
@@ -11,7 +11,7 @@ export const onMessageFromFCL = (msg, cb = () => {}) => {
     const {data} = e
     if (typeof data !== "object") return
     if (typeof data == null) return
-    if (data.type === msg) return
+    if (data.type !== messageType) return
 
     cb(buildData(data))
   }


### PR DESCRIPTION
### **EXPERIMENTAL** 

- Updates service strategies `POP/RPC` and `TAB/RPC` to use a single `window` when `authentication` is needed.
- Skips `close()` after resolving `execService` if no `currentUser` is saved in `localStorage`
- Uses `window.location.replace` to connect to the service that initiated the call