### PR TITLE
[fcl] Add CompositeSignature constructor to WalletUtils

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - YYYY-MM-DD **BREAKING?** -- description
+
+- 2021-09-14 -- Adds `WalletUtils.CompositeSignature` constructor.
 - 2021-08-27 -- Adds `config.fcl.storage` allowing for injection of desired storage option. Accepts `SESSION_STORAGE`, `LOCAL_STORAGE`, or `NO_STORAGE` and defaults to `SESSION_STORAGE`.
 
 ## 0.0.77-alpha.4 - 2021-08-27

--- a/packages/fcl/src/wallet-provider-spec/draft-v3.md
+++ b/packages/fcl/src/wallet-provider-spec/draft-v3.md
@@ -455,6 +455,15 @@ The eventual response back from the authorization service should resolve to some
 }
 ```
 
+A `CompositeSignature` can alternatively be constructed using `WalletUtils`
+
+```javascript
+import {WalletUtils} from "@onflow/fcl"
+
+WalletUtils.CompositeSignature(addr: String, keyId: Number, signature: Hex)
+
+```
+
 # User Signature Service
 
 User Signature services are depicted with a `type: "user-signature"` and a `method` of either `HTTP/POST`, `IFRAME/RPC` or `POP/RPC`.

--- a/packages/fcl/src/wallet-utils/CompositeSignature.js
+++ b/packages/fcl/src/wallet-utils/CompositeSignature.js
@@ -1,0 +1,10 @@
+import {withPrefix} from "@onflow/util-address"
+import {COMPOSITE_SIGNATURE_PRAGMA} from "../current-user/normalize/__vsn"
+
+export function CompositeSignature(addr, keyId, signature) {
+  this.f_type = COMPOSITE_SIGNATURE_PRAGMA.f_type
+  this.f_vsn = COMPOSITE_SIGNATURE_PRAGMA.f_vsn
+  this.addr = withPrefix(addr)
+  this.keyId = Number(keyId)
+  this.signature = signature
+}

--- a/packages/fcl/src/wallet-utils/index.js
+++ b/packages/fcl/src/wallet-utils/index.js
@@ -1,3 +1,4 @@
 export {sendMsgToFCL, close, approve, decline} from "./send-msg-to-fcl.js"
 export {onMessageFromFCL} from "./on-message-from-fcl.js"
 export {encodeMessageFromSignable} from "@onflow/sdk"
+export {CompositeSignature} from "./CompositeSignature.js"

--- a/packages/fcl/src/wallet-utils/wallet-utils.test.js
+++ b/packages/fcl/src/wallet-utils/wallet-utils.test.js
@@ -1,0 +1,16 @@
+import * as fcl from "../fcl"
+import {CompositeSignature} from "./CompositeSignature"
+
+describe("wallet utils", () => {
+  test("returns composite signature", () => {
+    const COMPOSITE_SIGNATURE = {
+      f_type: "CompositeSignature",
+      f_vsn: "1.0.0",
+      addr: "0x1",
+      keyId: 0,
+      signature: "foo",
+    }
+    const compSig = new CompositeSignature("1", 0, "foo")
+    expect(compSig).toEqual(COMPOSITE_SIGNATURE)
+  })
+})


### PR DESCRIPTION
### A `CompositeSignature` can be constructed using `WalletUtils`

- Add `WalletUtils.CompositeSignature`
- Update wallet-provider spec