### PR TITLE
PKG -- [fcl] Simplify currentUser syntax

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
-- 2021-09-16 -- Adds ability to access current user as `currentUser` as object instead of function (e.g. `currentUser()`)
+- 2021-09-16 -- Simplifies current user syntax from `currentUser()` to `currentUser`
 
 Examples of `currentUser` functionality.
 

--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-09-16 -- Adds ability to access current user as `currentUser` as object instead of function (e.g. `currentUser()`)
+
+Examples of `currentUser` functionality.
+
+```javascript
+import {currentUser} from "@onflow/fcl"
+
+currentUser.snapshot()
+currentUser.subscribe(callback)
+```
+
 - 2021-09-14 -- Adds `WalletUtils.CompositeSignature` constructor.
 - 2021-08-27 -- Adds `config.fcl.storage` allowing for injection of desired storage option. Accepts `SESSION_STORAGE`, `LOCAL_STORAGE`, or `NO_STORAGE` and defaults to `SESSION_STORAGE`.
 

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -277,7 +277,7 @@ async function verifyUserSignatures(msg, compSigs) {
   return verify(msg, compSigs)
 }
 
-export const currentUser = () => {
+let currentUser = () => {
   return {
     authenticate,
     unauthenticate,
@@ -285,6 +285,16 @@ export const currentUser = () => {
     signUserMessage,
     verifyUserSignatures,
     subscribe,
-    snapshot,
+    snapshot
   }
 }
+
+currentUser.authenticate = authenticate
+currentUser.unauthenticate = unauthenticate
+currentUser.authorization = authorization
+currentUser.signUserMessage = signUserMessage
+currentUser.verifyUserSignatures = verifyUserSignatures
+currentUser.subscribe = subscribe
+currentUser.snapshot = snapshot
+
+export {currentUser}


### PR DESCRIPTION
As noted in [this issue](https://github.com/onflow/fcl-js/issues/709), people are confused by having to get the current user via  a function. Instead, they'd expect it to be an object. This PR does the following:

- Simplifies `currentUser` syntax to be accessed as an object. For example, this will allow you to write `currentUser.snapshot()` instead of `currentUser().snapshot()`.
- Keeps supporting the existing way to obtaining the current user with `currentUser()`

Addresses issue: https://github.com/onflow/fcl-js/issues/709