### PR TITLE
PKG -- [fcl] warn if currentUser is being used server side

### DIFF
--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -1,14 +1,16 @@
 import {config} from "@onflow/sdk"
 import {invariant} from "@onflow/util-invariant"
 
+const isServerSide = () => typeof window === 'undefined'
+
 const SESSION_STORAGE = {
-  can: true,
+  can: !Boolean(isServerSide()),
   get: async key => JSON.parse(sessionStorage.getItem(key)),
   put: async (key, value) => sessionStorage.setItem(key, JSON.stringify(value)),
 }
 
 const LOCAL_STORAGE = {
-  can: true,
+  can: !Boolean(isServerSide()),
   get: async key => JSON.parse(localStorage.getItem(key)),
   put: async (key, value) => localStorage.setItem(key, JSON.stringify(value)),
 }

--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -4,13 +4,13 @@ import {invariant} from "@onflow/util-invariant"
 const isServerSide = () => typeof window === 'undefined'
 
 const SESSION_STORAGE = {
-  can: !Boolean(isServerSide()),
+  can: !isServerSide(),
   get: async key => JSON.parse(sessionStorage.getItem(key)),
   put: async (key, value) => sessionStorage.setItem(key, JSON.stringify(value)),
 }
 
 const LOCAL_STORAGE = {
-  can: !Boolean(isServerSide()),
+  can: !isServerSide(),
   get: async key => JSON.parse(localStorage.getItem(key)),
   put: async (key, value) => localStorage.setItem(key, JSON.stringify(value)),
 }

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -39,6 +39,20 @@ const getStoredUser = async storage => {
 
 const HANDLERS = {
   [INIT]: async ctx => {
+
+    if (typeof window === 'undefined') {
+      console.warn(
+        `
+        %cFCL Warning
+        ============================
+        "currentUser" is only available in the browser.
+        For more info, please see the docs: https://docs.onflow.org/fcl/
+        ============================
+        `,
+        "font-weight:bold;font-family:monospace;"
+      )
+    }
+
     ctx.merge(JSON.parse(DATA))
     const storage = await config.first(["fcl.storage", "fcl.storage.default"])
     if (storage.can) {


### PR DESCRIPTION
There is no warning if someone tries to use `currentUser` on the server side (for example, see this issue: https://github.com/onflow/fcl-js/issues/803#issuecomment-926905178). This adds a warning that `currentUser` is not available with a window check and links the docs.

Also, set storage to false for local and session storage if it's not the browser.