### PR TITLE
PKG -- [sdk] Resolve argument with specific resolveArgument method

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- Who: description
 
+- 2021-09-20 -- [@chasefleming](https://github.com/chasefleming): Resolve argument with specific `resolveArgument` method over generic `resolve`
 - 2021-09-20 -- [@chasefleming](https://github.com/chasefleming): Support asynchronous resolve methods in `resolveArguments`
 - 2021-09-20 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Adds wallet utility for encoding provable authentication messages.
 - 2021-08-05 -- [@gregsantos](https://github.com/gregsantos): Update `createSignableVoucher` structure and move to separate module.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 - YYYY-MM-DD **BREAKING?** -- Who: description
 
-- 2021-09-20 -- [@chasefleming](https://github.com/chasefleming): Resolve argument with specific `resolveArgument` method over generic `resolve`
+- 2021-09-20 -- [@chasefleming](https://github.com/chasefleming): Resolve asynchronous arguments with specific `resolveArgument` method over generic `resolve`
+
+### Example of resolveArgument for async args.
+
+```javascript
+const argument = {
+  async resolveArgument() {
+    return {
+      value: "0x12341324",
+      xform: t.Address,
+    }
+  }
+}
+
+sdk.args([
+  argument
+])
+```
+
 - 2021-09-20 -- [@chasefleming](https://github.com/chasefleming): Support asynchronous resolve methods in `resolveArguments`
 - 2021-09-20 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Adds wallet utility for encoding provable authentication messages.
 - 2021-08-05 -- [@gregsantos](https://github.com/gregsantos): Update `createSignableVoucher` structure and move to separate module.

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -183,6 +183,7 @@ export const makeArgument = arg => ix => {
   ix.arguments[tempId].asArgument = arg.asArgument
   ix.arguments[tempId].xform = arg.xform
   ix.arguments[tempId].resolve = arg.resolve
+  ix.arguments[tempId].resolveArgument = arg.resolveArgument
 
   return Ok(ix)
 }

--- a/packages/sdk/src/resolve/resolve-arguments.js
+++ b/packages/sdk/src/resolve/resolve-arguments.js
@@ -17,8 +17,8 @@ function cast(arg) {
 async function handleArgResolution(arg, depth = 3) {
   invariant(depth > 0, `Argument Resolve Recursion Limit Exceeded for Arg: ${arg.tempId}`)
 
-  if (isFn(arg.resolve)) {
-    const resolvedArg = await arg.resolve()
+  if (isFn(arg.resolveArgument)) {
+    const resolvedArg = await arg.resolveArgument()
     return handleArgResolution(resolvedArg, depth - 1)
   } else {
     return arg

--- a/packages/sdk/src/resolve/resolve-arguments.test.js
+++ b/packages/sdk/src/resolve/resolve-arguments.test.js
@@ -20,6 +20,7 @@ describe("resolveArguments", () => {
           asArgument: null,
           kind,
           resolve: undefined,
+          resolveArgument: undefined,
           tempId,
           value: argObj.value,
           xform: {
@@ -41,7 +42,8 @@ describe("resolveArguments", () => {
         [argID]: {
           asArgument: null,
           kind,
-          resolve: jest.fn().mockResolvedValue({
+          resolve: jest.fn(),
+          resolveArgument: jest.fn().mockResolvedValue({
             xform: {
               asArgument: () => argObj
             }
@@ -57,7 +59,8 @@ describe("resolveArguments", () => {
     }
 
     const res = await resolveArguments(ix)
-    expect(res.arguments[argID].resolve).toHaveBeenCalled()
+    expect(res.arguments[argID].resolve).not.toHaveBeenCalled()
+    expect(res.arguments[argID].resolveArgument).toHaveBeenCalled()
     expect(res.arguments[argID].asArgument).toEqual(argObj)
   })
 
@@ -75,11 +78,12 @@ describe("resolveArguments", () => {
         [argID]: {
           asArgument: null,
           kind,
-          resolve: jest.fn().mockResolvedValue({
+          resolve: undefined,
+          resolveArgument: jest.fn().mockResolvedValue({
             xform: {
               asArgument: () => argObj
             },
-            resolve: resolveTwo
+            resolveArgument: resolveTwo
           }),
           tempId,
           value: null,
@@ -92,7 +96,7 @@ describe("resolveArguments", () => {
     }
 
     const res = await resolveArguments(ix)
-    expect(res.arguments[argID].resolve).toHaveBeenCalled()
+    expect(res.arguments[argID].resolveArgument).toHaveBeenCalled()
     expect(resolveTwo).toHaveBeenCalled()
     expect(res.arguments[argID].asArgument).toEqual(argObj)
   })
@@ -104,17 +108,18 @@ describe("resolveArguments", () => {
         [argID]: {
           asArgument: null,
           kind,
-          resolve: jest.fn().mockResolvedValue({
+          resolve: undefined,
+          resolveArgument: jest.fn().mockResolvedValue({
             tempId: "1",
             xform: {
               asArgument: () => argObj
             },
-            resolve: jest.fn().mockResolvedValue({
+            resolveArgument: jest.fn().mockResolvedValue({
               tempId: "2",
               xform: {
                 asArgument: () => argObj
               },
-              resolve: jest.fn().mockResolvedValue({
+              resolveArgument: jest.fn().mockResolvedValue({
                 tempId: "3",
                 xform: {
                   asArgument: () => argObj


### PR DESCRIPTION
SDK changes to address feedback in this PR: https://github.com/onflow/fcl-js/pull/811

Changing the resolve arguments step to use more specific method naming as opposed to a generic resolve method.