### PR TITLE
DOC -- [root] change comment syntax in quickstart

### DIFF
--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -195,8 +195,8 @@ function App() {
     return (
       <div>
         <div>Address: {user?.addr ?? "No Address"}</div>
-        <div>Profile Name: {name ?? "--"}</div> // NEW
-        <button onClick={sendQuery}>Send Query</button> // NEW
+        <div>Profile Name: {name ?? "--"}</div> {/* NEW */}
+        <button onClick={sendQuery}>Send Query</button> {/* NEW */}
         <button onClick={fcl.unauthenticate}>Log Out</button>
       </div>
     )
@@ -358,7 +358,7 @@ function App() {
         <div>Address: {user?.addr ?? "No Address"}</div>
         <div>Profile Name: {name ?? "--"}</div>
         <button onClick={sendQuery}>Send Query</button>
-        <button onClick={initAccount}>Init Account</button> // NEW
+        <button onClick={initAccount}>Init Account</button> {/* NEW */}
         <button onClick={fcl.unauthenticate}>Log Out</button>
       </div>
     )
@@ -511,10 +511,10 @@ function App() {
       <div>
         <div>Address: {user?.addr ?? "No Address"}</div>
         <div>Profile Name: {name ?? "--"}</div>
-        <div>Transaction Status: {transactionStatus ?? "--"}</div> // NEW
+        <div>Transaction Status: {transactionStatus ?? "--"}</div> {/* NEW */}
         <button onClick={sendQuery}>Send Query</button>
         <button onClick={initAccount}>Init Account</button>
-        <button onClick={executeTransaction}>Execute Transaction</button> // NEW
+        <button onClick={executeTransaction}>Execute Transaction</button> {/* NEW */}
         <button onClick={fcl.unauthenticate}>Log Out</button>
       </div>
     )


### PR DESCRIPTION
In the JSX examples, comments for new sections are showing in the browser if you copy/paste. This converts the comments to JSX syntax so they are hidden.