### PR TITLE
DOC -- [fcl] Link headings in quickstart

### DIFF
--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -10,12 +10,12 @@ We're going to make an assumption that you know or understand React; however, th
 
 In this tutorial, we are going to interact with an existing smart contract on Flow's testnet known as the [Profile Contract](https://testnet.flowscan.org/contract/A.ba1132bc08f82fe2.Profile). Using this contract, we will create a new profile and edit the profile information, both via a wallet. In order to do this, the FCL concepts we'll cover are:
 
-- Installation
-- Configuration
-- Authentication
-- Querying the Blockchain
-- Initializing an Account
-- Mutating the Blockchain
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Authentication](#authentication)
+- [Querying the Blockchain](#querying-the-blockchain)
+- [Initializing an Account](#initializing-an-account)
+- [Mutating the Blockchain](#mutating-the-blockchain)
 
 And if you ever have any questions we're always happy to help on [Discord](https://discord.gg/flow). There are also links at the end of this article for diving deeper into building on Flow.
 


### PR DESCRIPTION
Reader should be able to browse to the section they need. This links the headings to the page sections.