### PR TITLE
fixes fcl.events.subscribe

### DIFF
--- a/packages/fcl/src/events/index.js
+++ b/packages/fcl/src/events/index.js
@@ -1,6 +1,6 @@
 import {spawn, subscriber, SUBSCRIBE, UNSUBSCRIBE} from "@onflow/util-actor"
 import {config, latestBlock} from "@onflow/sdk"
-export {getEvents} from "@onflow/sdk"
+import {getEvents} from "@onflow/sdk"
 import {send} from "@onflow/sdk"
 import {decode} from "@onflow/sdk"
 


### PR DESCRIPTION
Event subscriptions were failing with getEvents undefined error. 

example sandbox:

https://codesandbox.io/s/topshot-fetch-moments-listed-forked-2k9di?file=/src/App.js

I tried to write a test but couldn't succeed :(
