### PR TITLE
[fcl][verify] adopt hash algo by key's hash algo

### DIFF
--- a/packages/fcl/src/exec/verify.js
+++ b/packages/fcl/src/exec/verify.js
@@ -11,6 +11,7 @@ export async function verifyUserSignatures(msg, compSigs) {
 
   let weights = []
   let signAlgos = []
+  let hashAlgos = []
   let signatures = []
   const rawPubKeys = await Promise.all(
     compSigs.map(async cs => {
@@ -22,6 +23,7 @@ export async function verifyUserSignatures(msg, compSigs) {
         const account = await account(cs.addr)
         weights.push(account.keys[cs.keyId].weight.toFixed(1))
         signAlgos.push(account.keys[cs.keyId].signAlgo)
+        hashAlgos.push(account.keys[cs.keyId].hashAlgo)
         signatures.push(cs.signature)
         return account.keys[cs.keyId].publicKey
       } catch (err) {
@@ -37,6 +39,7 @@ export async function verifyUserSignatures(msg, compSigs) {
       arg(rawPubKeys, t.Array([t.String])),
       arg(weights, t.Array(t.UFix64)),
       arg(signAlgos, t.Array([t.UInt])),
+      arg(hashAlgos, t.Array([t.UInt])),
       arg(signatures, t.Array([t.String])),
     ],
   })
@@ -44,12 +47,30 @@ export async function verifyUserSignatures(msg, compSigs) {
 
 const VERIFY_SIG_SCRIPT = `
 import Crypto
+
+pub fun getHashAlgo(_ x: Int): HashAlgorithm {
+  switch x {
+  case 1:
+      return HashAlgorithm.SHA2_256
+  case 2:
+      return HashAlgorithm.SHA2_384
+  case 3:
+      return HashAlgorithm.SHA3_256
+  case 4:
+      return HashAlgorithm.SHA3_384
+  case 5:
+      return HashAlgorithm.KMAC128_BLS_BLS12_381
+  default:
+      return HashAlgorithm.SHA3_256
+  }
+}
     
 pub fun main(
   message: String,
   rawPublicKeys: [String],
   weights: [UFix64],
   signAlgos: [UInt],
+  hashAlgos: [UInt],
   signatures: [String],
 ): Bool {
 
@@ -62,7 +83,7 @@ pub fun main(
         publicKey: rawPublicKey.decodeHex(),
         signatureAlgorithm: signAlgos[i] == 2 ? SignatureAlgorithm.ECDSA_P256 : SignatureAlgorithm.ECDSA_secp256k1 
       ),
-      hashAlgorithm: HashAlgorithm.SHA3_256,
+      hashAlgorithm: getHashAlgo(Int(hashAlgos[i])),
       weight: weights[i],
     )
     i = i + 1


### PR DESCRIPTION
In some specific hardware key environments, SHA3_256 is not included. However, fcl uses SHA3_256 as the *only* hash algorithm when verifying user message and signature. 
The hash algorithm bound to the key for user signature verification will be a better choice.