### PR TITLE
[fcl] Update authz to dedupe accounts

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- 2021-12-01 -- Internal: Wrap authz in resolve to dedupe accounts. Remove user `notExpired` check.
 - 2021-11-22 -- Updates to use account key `HashAlgorithm` in `verifyUSerSignatures` instead of default `SHA3_256`
 - 2021-11-19 -- Update `buildUser` with with correct data prop for `expiresAt`
 


### PR DESCRIPTION
### Wraps authz in resolve

- Dedupe accounts and limit multiple calls to authz/authn
- Remove user `notExpired` check as always `false` due to Blocto returning past unix timestamp