### PR TITLE
PKG -- [fcl] Support include filtering for discovery.wallet

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -6,7 +6,9 @@
 ```javascript
 import { config } from "@onflow/fcl"
 
+// Include supports discovery.wallet or discovery.authn.endpoint
 config({
+  "discovery.wallet": "http://localhost:5000/testnet/authn",
   "discovery.authn.endpoint": "https://fcl-discovery.onflow.org/api/testnet/authn",
   "discovery.authn.include": ["0x123"] // Service account address
 })

--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -8,7 +8,7 @@ import { config } from "@onflow/fcl"
 
 // Include supports discovery.wallet or discovery.authn.endpoint
 config({
-  "discovery.wallet": "http://localhost:5000/testnet/authn",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn",
   "discovery.authn.endpoint": "https://fcl-discovery.onflow.org/api/testnet/authn",
   "discovery.authn.include": ["0x123"] // Service account address
 })

--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -1,5 +1,6 @@
 import {config} from "@onflow/sdk"
 import {invariant} from "@onflow/util-invariant"
+import {constructApiQueryParams} from "./discovery/services"
 
 const isServerSide = () => typeof window === "undefined"
 
@@ -32,10 +33,14 @@ export async function configLens(regex) {
 }
 
 export async function buildAuthnConfig() {
-  const discoveryWallet = await config.first([
+  const discoveryWalletUrl = await config.first([
     "discovery.wallet",
     "challenge.handshake",
   ])
+
+  const include = await config.get("discovery.authn.include", [])
+  const queryParams = constructApiQueryParams({include})
+  const discoveryWallet = `${discoveryWalletUrl}${queryParams}`
 
   const discoveryWalletMethod = await config.first([
     "discovery.wallet.method",

--- a/packages/fcl/src/discovery/services.js
+++ b/packages/fcl/src/discovery/services.js
@@ -6,7 +6,11 @@ const asyncPipe = (...fns) => input => fns.reduce((chain, fn) => chain.then(fn),
 async function addServices(services = []) {
   const endpoint = await config.get("discovery.authn.endpoint")
   invariant(Boolean(endpoint), `"discovery.authn.endpoint" in config must be defined.`)
-  const url = new URL(endpoint)
+
+  const include = await config.get("discovery.authn.include", [])
+  const queryParams = constructApiQueryParams({include})
+  const constructedEndpoint = `${endpoint}${queryParams}`
+  const url = new URL(constructedEndpoint)
 
   return fetch(url, {
     method: "GET",
@@ -41,3 +45,14 @@ export const getServices = ({ type }) => asyncPipe(
   s => filterServicesByType(s, type),
   filterOptInServices
 )([])
+
+export const constructApiQueryParams = ({ include }) => {
+  let queryStr = '?'
+  
+  if (include) {
+    let includeQueryStr = include.map(addr => `include=${addr}`).join('&')
+    queryStr = queryStr.concat(includeQueryStr)
+  }
+
+  return queryStr
+}

--- a/packages/fcl/src/discovery/services.js
+++ b/packages/fcl/src/discovery/services.js
@@ -47,12 +47,12 @@ export const getServices = ({ type }) => asyncPipe(
 )([])
 
 export const constructApiQueryParams = ({ include }) => {
-  let queryStr = '?'
+  let queryStr = ''
   
   if (include) {
-    let includeQueryStr = include.map(addr => `include=${addr}`).join('&')
+    const includeQueryStr = include.map(addr => `include=${addr}`).join('&')
     queryStr = queryStr.concat(includeQueryStr)
   }
 
-  return queryStr
+  return queryStr.length ? `?${queryStr}` : ''
 }

--- a/packages/fcl/src/discovery/services.test.js
+++ b/packages/fcl/src/discovery/services.test.js
@@ -1,4 +1,4 @@
-import {getServices} from "./services"
+import {constructApiQueryParams, getServices} from "./services"
 import {config} from "@onflow/sdk"
 
 const serviceOne = {
@@ -119,5 +119,15 @@ describe("getServices", () => {
     const expectedResponse = [serviceThree, serviceOne, serviceFour]
     expect(response).toEqual(expectedResponse)
     expect(response.length).toEqual(3)
+  })
+})
+
+describe("constructApiQueryParams", () => {
+  it("it should construct API query params", () => {
+    const filters = {
+      include: ["0x1", "0x2"]
+    }
+
+    expect(constructApiQueryParams(filters)).toEqual("?include=0x1&include=0x2")
   })
 })

--- a/packages/fcl/src/discovery/services.test.js
+++ b/packages/fcl/src/discovery/services.test.js
@@ -130,4 +130,15 @@ describe("constructApiQueryParams", () => {
 
     expect(constructApiQueryParams(filters)).toEqual("?include=0x1&include=0x2")
   })
+
+  it("it should return an empty string if nothing to construct", () => {
+    const filters = {
+      include: []
+    }
+
+    const filtersTwo = {}
+
+    expect(constructApiQueryParams(filters)).toEqual("")
+    expect(constructApiQueryParams(filtersTwo)).toEqual("")
+  })
 })


### PR DESCRIPTION
Add `include` filtering support for `discovery.wallet`. Addresses: https://github.com/onflow/fcl-js/issues/899

Creates required params for routing to `discovery.wallet` if `discovery.authn.include` is set in config.