### PR TITLE
[fcl] Adds optional Authentication Refresh Service to `fcl.authenticate`

### DIFF
--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -1,9 +1,6 @@
 import {config} from "@onflow/sdk"
-<<<<<<< HEAD
 import {constructApiQueryParams} from "./discovery/services"
 import {VERSION} from "./VERSION"
-=======
->>>>>>> 3e41103 (PKG -- [fcl] Add buildDiscoveryService to authenticate)
 
 const isServerSide = () => typeof window === "undefined"
 

--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -1,6 +1,9 @@
 import {config} from "@onflow/sdk"
+<<<<<<< HEAD
 import {constructApiQueryParams} from "./discovery/services"
 import {VERSION} from "./VERSION"
+=======
+>>>>>>> 3e41103 (PKG -- [fcl] Add buildDiscoveryService to authenticate)
 
 const isServerSide = () => typeof window === "undefined"
 
@@ -32,7 +35,7 @@ export async function configLens(regex) {
   )
 }
 
-export async function buildAuthnConfig() {
+export async function getDiscoveryService() {
   const discoveryWalletUrl = await config.first([
     "discovery.wallet",
     "challenge.handshake",
@@ -47,7 +50,9 @@ export async function buildAuthnConfig() {
     "discovery.wallet.method.default",
   ])
 
-  const appDomainTag = await config.get("fcl.appDomainTag")
-
-  return {discoveryWallet, discoveryWalletMethod, appDomainTag}
+  return {
+    type: "authn",
+    endpoint: discoveryWallet,
+    method: discoveryWalletMethod,
+  }
 }

--- a/packages/fcl/src/current-user/normalize/authn-refresh.js
+++ b/packages/fcl/src/current-user/normalize/authn-refresh.js
@@ -1,0 +1,22 @@
+// {
+//   "f_type": "Service",
+//   "f_vsn": "1.0.0",
+//   "type": "authn-refresh",
+//   "uid": "uniqueDedupeKey",
+//   "endpoint": "https://rawr",
+//   "method": "HTTP/POST", // HTTP/POST | IFRAME/RPC | HTTP/RPC
+//   "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // wallets internal id for the user
+//   "data": {}, // included in body of request
+//   "params": {}, // included as query params on endpoint url
+// }
+export function normalizeAuthnRefresh(service) {
+  if (service == null) return null
+
+  switch (service["f_vsn"]) {
+    case "1.0.0":
+      return service
+
+    default:
+      throw new Error("Invalid authn-refresh service")
+  }
+}

--- a/packages/fcl/src/current-user/normalize/authn-refresh.js
+++ b/packages/fcl/src/current-user/normalize/authn-refresh.js
@@ -4,7 +4,7 @@
 //   "type": "authn-refresh",
 //   "uid": "uniqueDedupeKey",
 //   "endpoint": "https://rawr",
-//   "method": "HTTP/POST", // HTTP/POST | IFRAME/RPC | HTTP/RPC
+//   "method": "HTTP/POST",  // "HTTP/POST", // HTTP/POST | IFRAME/RPC | HTTP/RPC
 //   "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // wallets internal id for the user
 //   "data": {}, // included in body of request
 //   "params": {}, // included as query params on endpoint url

--- a/packages/fcl/src/current-user/normalize/service.js
+++ b/packages/fcl/src/current-user/normalize/service.js
@@ -7,6 +7,7 @@ import {normalizeOpenId} from "./open-id"
 import {normalizeUserSignature} from "./user-signature"
 import {normalizeLocalView} from "./local-view"
 import {normalizeAccountProof} from "./account-proof"
+import {normalizeAuthnRefresh} from "./authn-refresh"
 
 export function normalizeServices(services, data) {
   return services.map(service => normalizeService(service, data))
@@ -22,6 +23,7 @@ const serviceNormalizers = {
   "user-signature": normalizeUserSignature,
   "local-view": normalizeLocalView,
   "account-proof": normalizeAccountProof,
+  "authn-refresh": normalizeAuthnRefresh,
 }
 
 export function normalizeService(service, data) {


### PR DESCRIPTION
### Allows for optional Authentication Refresh Service to update `fcl.currentUser` session data before sending tx

There was no way to know if a user’s wallet provider session had expired or ended for other reasons.
This led to a situation where a user who is logged in to an app initiates a transaction which fails silently and without any clear error. The user needs to reauthenticate, but the client (and FCL) were unaware. 

Wallet Providers can now provide an optional **Authentication Refresh Service** to FCL upon initial configuration.
If provided, FCL will attempt to refresh the user's session by executing this service before a transaction.
This solution provides a standard way for the app to reauthenticate a user or inform them that their wallet session has expired.

FCL will use the `authn-refresh` service endpoint and method provided to request updated authentication data from the Wallet Provider.
The service is expected to reauthenticate the user or prompt for approval if required. 

If FCL receives back an APPROVED `PollingResponse`, it rebuilds `fcl.currentUser` with updated session data and services
and the Authentication Refresh process is complete.
The initial transaction can then be executed with confidence the user session is valid.

- Adds new `authn-refresh` service and normalizer
- Updates `fcl.authenticate` to execute before attempting to authorize tx if a user is logged in, and `auth-refresh` service is provided
- Renames/refactors building of default discoveryService