### PR TITLE
[fcl] Updates `fcl.verifyUserSignatures`

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- 2021-12-07 -- Internal: Updates `fcl.verifyUserSignatures` adding additional validation. Extends Cadence query script to add key weight threshold and enforces signatures need to be from a single account address.
+
 ## 0.0.78-alpha.9 - 2021-12-03
 
 - 2021-12-01 -- Internal: Wrap authz in resolve to dedupe accounts. Remove user `notExpired` check.

--- a/packages/fcl/src/exec/__tests__/verify-usig.test.js
+++ b/packages/fcl/src/exec/__tests__/verify-usig.test.js
@@ -1,0 +1,53 @@
+import {verifyUserSignatures, validateArgs} from "../verify"
+
+const message = Buffer.from("FOO").toString("hex")
+
+const compSigOne = {
+  f_type: "CompositeSignature",
+  f_vsn: "1.0.0",
+  addr: "0x123",
+  keyId: 0,
+  signature: "abc123",
+}
+
+const compSigTwo = {
+  f_type: "CompositeSignature",
+  f_vsn: "1.0.0",
+  addr: "0x123",
+  keyId: 0,
+  signature: "abc123",
+}
+
+const compSigThree = {
+  f_type: "CompositeSignature",
+  f_vsn: "1.0.0",
+  addr: "0x456",
+  keyId: 0,
+  signature: "abc123",
+}
+
+describe("verifyUserSignatures", () => {
+  it("should return true if valid args", async () => {
+    const compSigs = [compSigOne, compSigTwo]
+    const res = await validateArgs(message, compSigs)
+    expect.assertions(1)
+    expect(res).toEqual(true)
+  })
+
+  it("should reject if message is not hex string", async () => {
+    const compSigs = [compSigOne, compSigTwo]
+    expect.assertions(1)
+    await expect(verifyUserSignatures("FOO", compSigs)).rejects.toThrow(Error)
+  })
+
+  it("should reject if missing array of composite signatures", async () => {
+    expect.assertions(1)
+    await expect(verifyUserSignatures(message, null)).rejects.toThrow(Error)
+  })
+
+  it("should reject if compSigs are from different account addresses", async () => {
+    const compSigs = [compSigOne, compSigTwo, compSigThree]
+    expect.assertions(1)
+    await expect(verifyUserSignatures(message, compSigs)).rejects.toThrow(Error)
+  })
+})

--- a/packages/fcl/src/exec/verify.js
+++ b/packages/fcl/src/exec/verify.js
@@ -9,37 +9,23 @@ export async function verifyUserSignatures(msg, compSigs) {
     "Must include an Array of composite signatures"
   )
 
-  let weights = []
-  let signAlgos = []
-  let hashAlgos = []
+  const acctAddress = compSigs[0].addr
   let signatures = []
-  const rawPubKeys = await Promise.all(
-    compSigs.map(async cs => {
-      invariant(typeof cs.addr === "string", "addr must be a string")
-      invariant(typeof cs.keyId === "number", "keyId must be a number")
-      invariant(typeof cs.signature === "string", "signature must be a string")
-
-      try {
-        const account = await account(cs.addr)
-        weights.push(account.keys[cs.keyId].weight.toFixed(1))
-        signAlgos.push(account.keys[cs.keyId].signAlgo)
-        hashAlgos.push(account.keys[cs.keyId].hashAlgo)
-        signatures.push(cs.signature)
-        return account.keys[cs.keyId].publicKey
-      } catch (err) {
-        throw err
-      }
-    })
-  )
+  let keyIds = []
+  compSigs.map(cs => {
+    invariant(typeof cs.addr === "string", "addr must be a string")
+    invariant(typeof cs.keyId === "number", "keyId must be a number")
+    invariant(typeof cs.signature === "string", "signature must be a string")
+    signatures.push(cs.signature)
+    keyIds.push(cs.keyId)
+  })
 
   return await query({
     cadence: `${VERIFY_SIG_SCRIPT}`,
     args: (arg, t) => [
+      arg(acctAddress, t.Address),
       arg(msg, t.String),
-      arg(rawPubKeys, t.Array([t.String])),
-      arg(weights, t.Array(t.UFix64)),
-      arg(signAlgos, t.Array([t.UInt])),
-      arg(hashAlgos, t.Array([t.UInt])),
+      arg(keyIds, t.Array([t.Int])),
       arg(signatures, t.Array([t.String])),
     ],
   })
@@ -66,25 +52,53 @@ const VERIFY_SIG_SCRIPT = `
   }
       
   pub fun main(
+    acctAddress: Address,
     message: String,
-    rawPublicKeys: [String],
-    weights: [UFix64],
-    signAlgos: [UInt],
-    hashAlgos: [UInt],
+    keyIds: [Int],
     signatures: [String],
   ): Bool {
 
     let keyList = Crypto.KeyList()
+    let rawPublicKeys: [String] = []
+    let weights: [UFix64] = []
+    let signAlgos: [UInt] = []
+    let hashAlgos: [UInt] = []
+    let uniqueKeys: {Int: Bool} = {}
+    let account = getAccount(acctAddress)
     
+    for id in keyIds {
+      uniqueKeys[id] = true
+    }
+
+    assert(uniqueKeys.keys.length == keyIds.length, message: "Invalid KeyId: Duplicate key found for account")
+
+    var counter = 0
+    while (counter < keyIds.length) {
+      let accountKey = account.keys.get(keyIndex: keyIds[counter]) ?? panic("Key provided does not exist on account")
+      rawPublicKeys.append(String.encodeHex(accountKey.publicKey.publicKey))
+      weights.append(accountKey.weight)
+      signAlgos.append(UInt(accountKey.publicKey.signatureAlgorithm.rawValue))
+      hashAlgos.append(UInt(accountKey.hashAlgorithm.rawValue))
+      counter = counter + 1
+    }
+
+    var totalWeight = 0.0
+    var weightIndex = 0
+    while (weightIndex < weights.length) {
+      totalWeight = totalWeight + weights[weightIndex]
+      weightIndex = weightIndex + 1
+    }
+    assert(totalWeight >= 1000.0, message: "Signature key weights do not meet threshold >= 1000.0")
+
     var i = 0
     for rawPublicKey in rawPublicKeys {
       keyList.add(
         PublicKey(
           publicKey: rawPublicKey.decodeHex(),
-          signatureAlgorithm: signAlgos[i] == 2 ? SignatureAlgorithm.ECDSA_P256 : SignatureAlgorithm.ECDSA_secp256k1 
+          signatureAlgorithm: signAlgos[i] == 2 ? SignatureAlgorithm.ECDSA_secp256k1  : SignatureAlgorithm.ECDSA_P256
         ),
         hashAlgorithm: getHashAlgo(Int(hashAlgos[i])),
-        weight: weights[i],
+        weight: weights[i]
       )
       i = i + 1
     }

--- a/packages/fcl/src/exec/verify.js
+++ b/packages/fcl/src/exec/verify.js
@@ -1,21 +1,27 @@
 import {invariant} from "@onflow/util-invariant"
 import {query} from "../exec/query"
-import {account} from "@onflow/sdk"
+
+export const validateArgs = (msg, compSigs) => {
+  invariant(/^[0-9a-f]+$/i.test(msg), "Signed message must be a hex string")
+  invariant(
+    Array.isArray(compSigs) &&
+      compSigs.every((sig, i, arr) => sig.f_type === "CompositeSignature"),
+    "Must include an Array of CompositeSignatures to verify"
+  )
+  invariant(
+    compSigs.map(cs => cs.addr).every((addr, i, arr) => addr === arr[0]),
+    "User signatures to be verified must be from a single account address"
+  )
+  return true
+}
 
 export async function verifyUserSignatures(msg, compSigs) {
-  invariant(/^[0-9a-f]+$/i.test(msg), "Message must be a hex string")
-  invariant(
-    Array.isArray(compSigs),
-    "Must include an Array of composite signatures"
-  )
+  validateArgs(msg, compSigs)
 
   const acctAddress = compSigs[0].addr
   let signatures = []
   let keyIds = []
   compSigs.map(cs => {
-    invariant(typeof cs.addr === "string", "addr must be a string")
-    invariant(typeof cs.keyId === "number", "keyId must be a number")
-    invariant(typeof cs.signature === "string", "signature must be a string")
     signatures.push(cs.signature)
     keyIds.push(cs.keyId)
   })


### PR DESCRIPTION
### Updates to `fcl.verifyUserSignatures` and query script

- Adds validation to enforce signatures need to be from a single account address
- Removes extra script to get account keys by moving into script
- Updates Cadence query script
 - Deals with getting account key, and enforces no duplicate keys
 - Adds key weight threshold