### PR TITLE
fix broken internal link in reference/api.md doc

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -346,7 +346,7 @@ fcl.authenticate();
 
 #### Note
 
-⚠️ `authenticate` can also take a service returned from (discovery)[#discovery] with `fcl.authenticate({ service })`.
+⚠️ `authenticate` can also take a service returned from [discovery](#discovery) with `fcl.authenticate({ service })`.
 
 #### Examples
 


### PR DESCRIPTION
in the authenticate section, the internal link to discovery is written in the incorrect format of Markdown link.

https://docs.onflow.org/fcl/reference/api/#authenticate
![image](https://user-images.githubusercontent.com/10865414/145554244-97e1c406-2e54-4045-94df-64d9b40ef435.png)
