### PR TITLE
fix anchor path for account object

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1442,9 +1442,9 @@ A pre-built interaction that returns the details of an account from their public
 
 #### Returns
 
-| Type                      | Description                              |
-| ------------------------- | ---------------------------------------- |
-| [AccountObject](#account) | A JSON representation of a user account. |
+| Type                            | Description                              |
+| ------------------------------- | ---------------------------------------- |
+| [AccountObject](#accountobject) | A JSON representation of a user account. |
 
 #### Usage
 


### PR DESCRIPTION
anchor link to account object is set wrong path.


https://docs.onflow.org/fcl/reference/api/#getaccount

