### PR TITLE
use relative link when referring to FCL documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i -S @onflow/fcl @onflow/types
 yarn add @onflow/fcl @onflow/types
 ```
 
-### Learn to use `@onflow/fcl`: [Flow App Quickstart](https://docs.onflow.org/fcl/flow-app-quickstart/)
+### Learn to use `@onflow/fcl`: [Flow App Quickstart](./docs/tutorials/flow-app-quickstart.mdx)
 
 ---
 ## Requirements

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -56,7 +56,7 @@ npm i -S @onflow/fcl @onflow/types
 
 ```
 
-### Learn to use `@onflow/fcl`: [Flow App Quickstart](https://docs.onflow.org/fcl/tutorials/flow-app-quickstart/)
+### Learn to use `@onflow/fcl`: [Flow App Quickstart](tutorials/flow-app-quickstart.mdx)
 
 ---
 

--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -63,7 +63,7 @@ config({
 The `accessNode.api` key specifies the address of a Flow access node. Flow provides these, but in the future access to Flow may be provided by other 3rd parties, through their own access nodes.
 `discovery.wallet` is an address that points to a service that lists FCL compatible wallets. Flow's FCL Discovery service is a service that FCL wallet providers can be added to, and be made 'discoverable' to any application that uses the `discovery.wallet` endpoint.
 
-Learn more about configuration values [here](https://docs.onflow.org/fcl/reference/api/#setting-configuration-values).
+Learn more about configuration values [here](../reference/api.md#setting-configuration-values).
 
 To finish configuring our dapp, let's import the config file into the top of our `App.js` file, then swap out the default component in `App.js` to look like this:
 
@@ -88,7 +88,7 @@ Now we're ready to start talking to Flow!
 
 ## Authentication
 
-To authenticate a user, all an app has to do is call `fcl.logIn()`. Sign up and unauthenticate are all also as simple as `fcl.signUp()` and `fcl.unauthenticate()`.  Once authenticated, FCL sets an object called `fcl.currentUser` which exposes methods for watching changes in user data, signing transactions, and more. For more information on the `currentUser`, read more [here](https://docs.onflow.org/fcl/reference/api/#current-user).
+To authenticate a user, all an app has to do is call `fcl.logIn()`. Sign up and unauthenticate are all also as simple as `fcl.signUp()` and `fcl.unauthenticate()`.  Once authenticated, FCL sets an object called `fcl.currentUser` which exposes methods for watching changes in user data, signing transactions, and more. For more information on the `currentUser`, read more [here](../reference/api.md#current-user).
 
 Let's add in a few buttons for sign up/login and also subscribe to changes on the `currentUser`. When the user is updated (which it will be after authentication), we'll set the user state in our component to reflect this. To demonstrate user authenticated sessions, we'll conditionally render a component based on if the user is or is not logged in.
 
@@ -252,7 +252,7 @@ await fcl.query({
 
 Inside the query you'll see we set two things: `cadence` and `args`. Cadence is Flow's smart contract language we mentioned. For this tutorial, when you look at it you just need to notice that it's importing the `Profile` contract from the account we named `0xProfile` earlier in our config file, then also taking an account address, and reading it. That's it until you're ready to [learn more Cadence](https://docs.onflow.org/cadence/tutorial/01-first-steps/).
 
-In the `args` section, we are simply passing it our user's account address from the user we set in state after authentication and giving it a type of `Address`.  For more possible types, [see this reference](https://docs.onflow.org/fcl/reference/api/#ftype).
+In the `args` section, we are simply passing it our user's account address from the user we set in state after authentication and giving it a type of `Address`.  For more possible types, [see this reference](../reference/api.md#ftype).
 
 Go ahead and click the "Send Query" button. You should see "No Profile." That's because we haven't initialized the account yet.
 
@@ -555,7 +555,7 @@ export default App;
 
 ```
 
-Now if you click the "Execute Transaction" button you'll see the statuses update next to "Transaction Status." When you see "4" that means it's sealed! Status code meanings [can be found here](https://docs.onflow.org/fcl/reference/api/#transaction-statuses).
+Now if you click the "Execute Transaction" button you'll see the statuses update next to "Transaction Status." When you see "4" that means it's sealed! Status code meanings [can be found here](../reference/api.md#transaction-statuses).
 
 That's it! You now have a shippable Flow dapp that can auth, query, init accounts, and mutate the chain. This is just the beginning. There is so much more to know. We have a lot more resources to help you build. To dive deeper, here are a few good places for taking the next steps:
 
@@ -569,11 +569,11 @@ That's it! You now have a shippable Flow dapp that can auth, query, init account
 - [Advanced Example: Kitty Items](https://github.com/onflow/kitty-items)
 
 **More FCL**
-- [FCL API Quick Reference](https://docs.onflow.org/fcl/reference/api/)
-- [More on Scripts](https://docs.onflow.org/fcl/reference/scripts/)
-- [More on Transactions](https://docs.onflow.org/fcl/reference/transactions/)
-- [User Signatures](https://docs.onflow.org/fcl/reference/user-signatures/)
-- [Proving Account Ownership](https://docs.onflow.org/fcl/reference/proving-authentication/)
+- [FCL API Quick Reference](../reference/api.md)
+- [More on Scripts](../reference/scripts.mdx)
+- [More on Transactions](../reference/transactions.mdx)
+- [User Signatures](../reference/user-signatures.mdx)
+- [Proving Account Ownership](../reference/proving-authentication.mdx)
 
 **Other**
 - [Flow Developer Onboarding Guide](https://docs.onflow.org/dapp-development/)


### PR DESCRIPTION
use relative links whenever possible in documentation so that when readers clicks the link in Github, they will be directed to Github pages; when readers click the link in docs.onflow.org, they will be directed to Flow doc site pages

## context
Our official doc site can not handle relative linking well in the past, however, we recently addressed that (https://github.com/onflow/flow/issues/704) so that we can write relative paths in Markdown (or .mdx) files. 