### PR TITLE
Update sdk-guidelines.mdx

### DIFF
--- a/docs/reference/sdk-guidelines.mdx
+++ b/docs/reference/sdk-guidelines.mdx
@@ -1,7 +1,7 @@
 <br />
 <div align="center">
   <a href="">
-    <img src="./" alt="Logo" width="300" height="auto">
+    <img src="./" alt="Logo" width="300" height="auto" />
   </a>
   <p align="center"> <br />
     <a href=""><strong>View on GitHub »</strong></a> <br /><br />


### PR DESCRIPTION
Closed img tag as it was triggering an Error during flow-docs deployment:

```

error "gatsby-plugin-mdx" threw an error while running the onCreateNode lifecycle:

unknown: Expected corresponding JSX closing tag for <img> (11:2)
--
14:26:25.530 |  
14:26:25.530 |    9|   <a href="">
14:26:25.530 |   10|     <img src="./" alt="Logo" width="300" height="auto">
14:26:25.530 | > 11|   </a>

```

[Example build output](https://vercel.com/onflow/flow-docs/CKME8xGwXFHLDsEAs1ex6zHa16zS) 