### PR TITLE
[fcl] Update extension strategy

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- 2022-02-08 -- [gregsantos](https://github.com/gregsantos): Update extension strategy to add support for `EXT/RPC` service method
+
 ## 0.0.79-alpha.3 - 2022-02-03
 
 - 2022-02-03 -- [gregsantos](https://github.com/gregsantos): VSN `@onflow/sdk` 0.0.57-alpha.2 -> 0.0.57-alpha.3

--- a/packages/fcl/src/current-user/exec-service/strategies/ext-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/ext-rpc.js
@@ -1,13 +1,10 @@
+import {invariant} from "@onflow/util-invariant"
 import {extension} from "./utils/extension"
 import {normalizePollingResponse} from "../../normalize/polling-response"
 import {VERSION} from "../../../VERSION"
 
 export function execExtRPC(service, body, opts, config) {
   return new Promise((resolve, reject) => {
-    const {redir} = opts
-
-    body.data = service.data
-
     extension(service, {
       async onReady(_, {send}) {
         try {
@@ -22,21 +19,6 @@ export function execExtRPC(service, body, opts, config) {
             },
             config,
           })
-          send({
-            fclVersion: VERSION,
-            type: "FCL:FRAME:READY:RESPONSE",
-            body,
-            service: {
-              params: service.params,
-              data: service.data,
-              type: service.type,
-            },
-            config,
-            deprecated: {
-              message:
-                "FCL:FRAME:READY:RESPONSE is deprecated and replaced with type: FCL:VIEW:READY:RESPONSE",
-            },
-          })
         } catch (error) {
           throw error
         }
@@ -50,7 +32,7 @@ export function execExtRPC(service, body, opts, config) {
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              !redir && close()
+              close()
               break
 
             case "DECLINED":

--- a/packages/fcl/src/current-user/exec-service/strategies/ext-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/ext-rpc.js
@@ -1,10 +1,13 @@
-import {invariant} from "@onflow/util-invariant"
 import {extension} from "./utils/extension"
 import {normalizePollingResponse} from "../../normalize/polling-response"
 import {VERSION} from "../../../VERSION"
 
 export function execExtRPC(service, body, opts, config) {
   return new Promise((resolve, reject) => {
+    const {redir} = opts
+
+    body.data = service.data
+
     extension(service, {
       async onReady(_, {send}) {
         try {
@@ -19,6 +22,21 @@ export function execExtRPC(service, body, opts, config) {
             },
             config,
           })
+          send({
+            fclVersion: VERSION,
+            type: "FCL:FRAME:READY:RESPONSE",
+            body,
+            service: {
+              params: service.params,
+              data: service.data,
+              type: service.type,
+            },
+            config,
+            deprecated: {
+              message:
+                "FCL:FRAME:READY:RESPONSE is deprecated and replaced with type: FCL:VIEW:READY:RESPONSE",
+            },
+          })
         } catch (error) {
           throw error
         }
@@ -32,7 +50,7 @@ export function execExtRPC(service, body, opts, config) {
           switch (resp.status) {
             case "APPROVED":
               resolve(resp.data)
-              close()
+              !redir && close()
               break
 
             case "DECLINED":

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
@@ -17,7 +17,7 @@ export function extension(service, opts = {}) {
   )
 
   send({
-    type: "FCL:OPEN:EXTENSION",
+    type: "FCL:LAUNCH:EXTENSION",
     service,
   })
 
@@ -28,7 +28,7 @@ export function extension(service, opts = {}) {
       window.removeEventListener("message", buildMessageHandler)
       onClose()
     } catch (error) {
-      console.error("Popup Close Error", error)
+      console.error("Ext Close Error", error)
     }
   }
 

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
@@ -1,36 +1,42 @@
 import {buildMessageHandler} from "./buildMessageHandler"
+
 const noop = () => {}
 
-export async function extension(service, opts = {}) {
+export function extension(service, opts = {}) {
   if (service == null) return {send: noop, close: noop}
-  const {endpoint: ext} = service
+  const url = new URL(service.endpoint)
 
   const onClose = opts.onClose || noop
   const onMessage = opts.onMessage || noop
   const onReady = opts.onReady || noop
   const onResponse = opts.onResponse || noop
 
+  window.addEventListener(
+    "message",
+    buildMessageHandler({close, send, onReady, onResponse, onMessage})
+  )
+
+  send({
+    type: "FCL:OPEN:EXTENSION",
+    service,
+  })
+
+  return {send, close}
+
   function close() {
     try {
       window.removeEventListener("message", buildMessageHandler)
       onClose()
     } catch (error) {
-      console.error("Extension Close Error", error)
+      console.error("Popup Close Error", error)
     }
   }
 
   function send(msg) {
     try {
-      window[ext]?.flow.send(JSON.parse(JSON.stringify(msg || {})))
+      window && window.postMessage(JSON.parse(JSON.stringify(msg || {})), "*")
     } catch (error) {
-      console.error("Extension Send Error", msg, error)
+      console.error("Ext Send Error", msg, error)
     }
   }
-
-  window.addEventListener(
-    "message",
-    buildMessageHandler({close, send, onReady, onResponse, onMessage})
-  )
-  await window[ext]?.flow.enable()
-  return {send, close}
 }

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/render-ext.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/render-ext.js
@@ -1,0 +1,36 @@
+const POP = "FCL_EXT"
+
+let popup = null
+let previousUrl = null
+
+function popupWindow(url, windowName, win, w, h) {
+  const y = win.top.outerHeight / 2 + win.top.screenY - h / 2
+  const x = win.top.outerWidth / 2 + win.top.screenX - w / 2
+  return win.open(
+    url,
+    windowName,
+    `toolbar=no, addressbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=${w}, height=${h}, top=${y}, left=${x}`
+  )
+}
+
+export function renderExt(src) {
+  if (popup == null || popup?.closed) {
+    popup = popupWindow(src, POP, window, 375, 598)
+  } else if (previousUrl !== src) {
+    popup.location.replace(src)
+    popup.focus()
+  } else {
+    popup.focus()
+  }
+
+  previousUrl = src
+
+  const unmount = () => {
+    if (popup && !popup.closed) {
+      popup.close()
+    }
+    popup = null
+  }
+
+  return [popup, unmount]
+}


### PR DESCRIPTION
### Update extension strategy to add support for `EXT/RPC` service method

- When executed posts msg `type: "FCL:LAUNCH:EXTENSION"` and sets up listener for communication with browser extension.
- Extension should listen for msg `type: "FCL:LAUNCH:EXTENSION"` to enable ext/open popup window, and respond with `"FCL:VIEW:READY"`
- FCL will respond with `"FCL:VIEW:READY:RESPONSE"` type and service data, and wait for `PollingResponse`