### PR TITLE
DOC -- [root] Fix logIn casing

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,7 +32,7 @@
       - [Usage](#usage-2)
       - [Examples](#examples-2)
   - [`signUp`](#signup)
-  - [`login`](#login)
+  - [`logIn`](#login)
   - [`authz`](#authz)
       - [Returns](#returns)
       - [Usage](#usage-3)
@@ -422,7 +422,7 @@ A **convenience method** that calls and is equivalent to [`fcl.authenticate()`](
 
 ---
 
-## `login`
+## `logIn`
 
 > ⚠️**This method can only be used in web browsers.**
 


### PR DESCRIPTION
Hi, 



Noticed that in the doc it was coded as `login` instead of `logIn`. After researching the docs commit history, I saw that this was added in #729 and not changed since then. 
It was not working in my authentification, and was resolved using the correct casing. 

Hope to save some time to someone :) 