### PR TITLE
Send FCL client config data

### DIFF
--- a/packages/fcl/src/current-user/exec-service/index.js
+++ b/packages/fcl/src/current-user/exec-service/index.js
@@ -24,7 +24,7 @@ export async function execService({service, msg = {}, opts = {}, config = {}}) {
     client: {
       fclVersion: VERSION,
       fclLibrary: "https://github.com/onflow/fcl-js",
-      hostname: window.location.hostname
+      hostname: window?.location?.hostname ?? null
     }
   }
 

--- a/packages/fcl/src/current-user/exec-service/index.js
+++ b/packages/fcl/src/current-user/exec-service/index.js
@@ -5,6 +5,7 @@ import {execTabRPC} from "./strategies/tab-rpc"
 import {execExtRPC} from "./strategies/ext-rpc"
 import {invariant} from "@onflow/util-invariant"
 import {configLens} from "../../config-utils"
+import {VERSION} from "../../VERSION"
 
 const STRATEGIES = {
   "HTTP/RPC": execHttpPost,
@@ -20,6 +21,11 @@ export async function execService({service, msg = {}, opts = {}, config = {}}) {
     ...config,
     services: await configLens(/^service\./),
     app: await configLens(/^app\.detail\./),
+    client: {
+      fclVersion: VERSION,
+      fclLibrary: "https://github.com/onflow/fcl-js",
+      hostname: window.location.hostname
+    }
   }
 
   try {


### PR DESCRIPTION
More client metadata needs to be sent. We want to keep it set from configurable app data in a new object called `client`. Currently, in here we will send the library used to send the data, fcl version, and the hostname of the app sending the data.

Addresses: 
- https://github.com/onflow/fcl-js/issues/1029
- https://github.com/onflow/fcl-js/issues/1030