### PR TITLE
PKG -- [sdk] Setup field renamings/deprecations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @orodio @JeffreyDoyle @10thfloor @gregsantos @chasefleming
+* @JeffreyDoyle @10thfloor @gregsantos @chasefleming

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Allow developers to access new field names and warn on usage of field renamings/deprecations. To turn on warnings, set config `log.level` to `3`.
+
+```js
+sdk.config("log.level", 3)
+```
+
 - 2022-02-11 -- Uses Buffer from @onflow/rlp in encode.
 - 2022-02-11 -- Injects Buffer from @onflow/rlp to transport send modules.
 - 2022-02-04 -- [@chasefleming](https://github.com/chasefleming): Add options for for getting account by block height.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Allow developers to access new field names and warn on usage of field renamings/deprecations. To turn on warnings, set config `log.level` to `3`.
+- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `3`.
 
 ```js
 sdk.config("logger.level", 3)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
 
-- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `3`.
+- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `2`.
 
 ```js
-sdk.config("logger.level", 3)
+sdk.config("logger.level", 2)
 ```
 
 - 2022-02-11 -- Uses Buffer from @onflow/rlp in encode.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,7 +3,7 @@
 - 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Allow developers to access new field names and warn on usage of field renamings/deprecations. To turn on warnings, set config `log.level` to `3`.
 
 ```js
-sdk.config("log.level", 3)
+sdk.config("logger.level", 3)
 ```
 
 - 2022-02-11 -- Uses Buffer from @onflow/rlp in encode.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- 2022-03-11 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `2`.
+- 2022-03-16 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `2`.
 
 ```js
 sdk.config("logger.level", 2)

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -1,5 +1,5 @@
 import {invariant} from "@onflow/util-invariant"
-import {renameAndDeprecate} from "../utils/deprecate"
+import {applyRenamings} from "../utils/deprecate"
 
 export const UNKNOWN /*                       */ = "UNKNOWN"
 export const SCRIPT /*                        */ = "SCRIPT"
@@ -125,7 +125,7 @@ const PROP_DEPRECATIONS = new Map([
 
 export const interaction = () => {
   const ix = JSON.parse(IX)
-  const account = renameAndDeprecate(ix.account, PROP_DEPRECATIONS)
+  const account = applyRenamings(ix.account, PROP_DEPRECATIONS)
 
   return {
     ...ix,
@@ -171,7 +171,7 @@ export const prepAccount = (acct, opts = {}) => ix => {
   )
   invariant(opts.role != null, "Account must have a role")
 
-  const ACCOUNT = renameAndDeprecate(JSON.parse(ACCT), PROP_DEPRECATIONS)
+  const ACCOUNT = applyRenamings(JSON.parse(ACCT), PROP_DEPRECATIONS)
 
   const role = opts.role
   const tempId = uuid()

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -109,12 +109,6 @@ const IX = `{
 
 const KEYS = new Set(Object.keys(JSON.parse(IX)))
 
-const getByValue = (map, searchValue) => {
-  for (let [key, value] of map.entries()) {
-    if (value === searchValue) return key;
-  }
-}
-
 // Current field, followed by renaming
 // addr => address
 const PROP_DEPRECATIONS = new Map([

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -1,5 +1,5 @@
 import {invariant} from "@onflow/util-invariant"
-import {logger, LOGGER_LEVELS} from "../utils/logger"
+import {renameAndDeprecate} from "../utils/deprecate"
 
 export const UNKNOWN /*                       */ = "UNKNOWN"
 export const SCRIPT /*                        */ = "SCRIPT"
@@ -123,29 +123,9 @@ const PROP_DEPRECATIONS = new Map([
   ["keyId", "keyIndex"]
 ])
 
-const applyDeprecations = (originalObject, deprecated) => {
-  return new Proxy(originalObject, {
-    get: (obj, property) => {
-      if (getByValue(deprecated, property)) {
-        const originalProperty = getByValue(deprecated, property)
-        return Reflect.get(obj, originalProperty)
-      }
-      if (deprecated.has(property)) {
-        logger(
-          "FCL/SDK Deprecation Notice",
-          `"${property}" will be deprecated in a future version.
-          Please use "${deprecated.get(property)}" instead.`,
-          LOGGER_LEVELS.warn
-        )
-      }
-      return Reflect.get(obj, property)
-    }
-  })
-}
-
 export const interaction = () => {
   const ix = JSON.parse(IX)
-  const account = applyDeprecations(ix.account, PROP_DEPRECATIONS)
+  const account = renameAndDeprecate(ix.account, PROP_DEPRECATIONS)
 
   return {
     ...ix,
@@ -191,8 +171,7 @@ export const prepAccount = (acct, opts = {}) => ix => {
   )
   invariant(opts.role != null, "Account must have a role")
 
-  const ACCOUNT_OG = JSON.parse(ACCT)
-  const ACCOUNT = applyDeprecations(ACCOUNT_OG, PROP_DEPRECATIONS)
+  const ACCOUNT = renameAndDeprecate(JSON.parse(ACCT), PROP_DEPRECATIONS)
 
   const role = opts.role
   const tempId = uuid()

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -116,9 +116,9 @@ const LOGGER_LEVELS = {
 }
 
 const logger = async (title, message, level) => {
-  const logLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
+  const configLoggerLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
 
-  if (logLevel >= level) {
+  if (configLoggerLevel >= level) {
     console.warn(
       `
       %c${title}
@@ -208,7 +208,7 @@ const makeIx = wat => ix => {
   return Ok(ix)
 }
 
-export const prepAccount = (acct, opts = {}) => async (ix) => {
+export const prepAccount = (acct, opts = {}) => (ix) => {
   invariant(
     typeof acct === "function" || typeof acct === "object",
     "prepAccount must be passed an authorization function or an account object"

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -1,5 +1,5 @@
 import {invariant} from "@onflow/util-invariant"
-import {config} from "@onflow/sdk"
+import {config} from "../config"
 
 export const UNKNOWN /*                       */ = "UNKNOWN"
 export const SCRIPT /*                        */ = "SCRIPT"

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -208,7 +208,7 @@ const makeIx = wat => ix => {
   return Ok(ix)
 }
 
-export const prepAccount = (acct, opts = {}) => (ix) => {
+export const prepAccount = (acct, opts = {}) => ix => {
   invariant(
     typeof acct === "function" || typeof acct === "object",
     "prepAccount must be passed an authorization function or an account object"

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -1,5 +1,5 @@
 import {invariant} from "@onflow/util-invariant"
-import {config} from "../config"
+import {logger, LOGGER_LEVELS} from "../utils/logger"
 
 export const UNKNOWN /*                       */ = "UNKNOWN"
 export const SCRIPT /*                        */ = "SCRIPT"
@@ -106,30 +106,6 @@ const IX = `{
     "id":null
   }
 }`
-
-const LOGGER_LEVELS = {
-  "debug": 0,
-  "info": 1,
-  "log": 2,
-  "warn": 3,
-  "error": 4
-}
-
-const logger = async (title, message, level) => {
-  const configLoggerLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
-
-  if (configLoggerLevel >= level) {
-    console.warn(
-      `
-      %c${title}
-      ============================
-      ${message}
-      ============================
-      `,
-      "font-weight:bold;font-family:monospace;"
-    )
-  }
-}
 
 const KEYS = new Set(Object.keys(JSON.parse(IX)))
 

--- a/packages/sdk/src/utils/deprecate.js
+++ b/packages/sdk/src/utils/deprecate.js
@@ -37,6 +37,12 @@ export const deprecate = {
   error,
 }
 
+const getByValue = (map, searchValue) => {
+  for (let [key, value] of map.entries()) {
+    if (value === searchValue) return key;
+  }
+}
+
 // Allows access to old and new field names while showing deprecation warning for old
 export const applyRenamings = (originalObject, deprecationsMap) => {
   return new Proxy(originalObject, {

--- a/packages/sdk/src/utils/deprecate.js
+++ b/packages/sdk/src/utils/deprecate.js
@@ -38,7 +38,7 @@ export const deprecate = {
 }
 
 // Allows access to old and new field names while showing deprecation warning for old
-export const renameAndDeprecate = (originalObject, deprecationsMap) => {
+export const applyRenamings = (originalObject, deprecationsMap) => {
   return new Proxy(originalObject, {
     get: (obj, property) => {
       if (getByValue(deprecationsMap, property)) {

--- a/packages/sdk/src/utils/deprecate.js
+++ b/packages/sdk/src/utils/deprecate.js
@@ -1,3 +1,5 @@
+import {logger, LOGGER_LEVELS} from "./logger"
+
 const buildWarningMessage = ({name, transitionsPath}) => {
   console.warn(
     `
@@ -33,4 +35,25 @@ const error = deprecated => {
 export const deprecate = {
   warn,
   error,
+}
+
+// Allows access to old and new field names while showing deprecation warning for old
+export const renameAndDeprecate = (originalObject, deprecationsMap) => {
+  return new Proxy(originalObject, {
+    get: (obj, property) => {
+      if (getByValue(deprecationsMap, property)) {
+        const originalProperty = getByValue(deprecationsMap, property)
+        return Reflect.get(obj, originalProperty)
+      }
+      if (deprecationsMap.has(property)) {
+        logger(
+          "FCL/SDK Deprecation Notice",
+          `"${property}" will be deprecated in a future version.
+          Please use "${deprecationsMap.get(property)}" instead.`,
+          LOGGER_LEVELS.warn
+        )
+      }
+      return Reflect.get(obj, property)
+    }
+  })
 }

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -25,8 +25,15 @@ export const logger = async (title, message, level) => {
   if (configLoggerLevel < level) return
 
   switch(level) {
+    case LOGGER_LEVELS.debug:
+      console.debug(buildLoggerMessage(title, message))
+      break;
+    case LOGGER_LEVELS.info:
+      console.info(buildLoggerMessage(title, message))
+      break;
     case LOGGER_LEVELS.warn:
       console.warn(buildLoggerMessage(title, message))
+      break;
     case LOGGER_LEVELS.error:
       console.error(buildLoggerMessage(title, message))
       break;

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -8,14 +8,15 @@ export const LOGGER_LEVELS = {
   "error": 1
 }
 
-const buildLoggerMessage = (title, message) => {
-  return `
+const buildLoggerMessageArgs = ({title, message}) => {
+  return [`
     %c${title}
     ============================
     ${message}
     ============================
     `,
     "font-weight:bold;font-family:monospace;"
+  ]
 }
 
 export const logger = async (title, message, level) => {
@@ -24,20 +25,22 @@ export const logger = async (title, message, level) => {
   // If config level is below message level then don't show it
   if (configLoggerLevel < level) return
 
+  const loggerMessageArgs = buildLoggerMessageArgs({title, message})
+
   switch(level) {
     case LOGGER_LEVELS.debug:
-      console.debug(buildLoggerMessage(title, message))
+      console.debug(...loggerMessageArgs)
       break;
     case LOGGER_LEVELS.info:
-      console.info(buildLoggerMessage(title, message))
+      console.info(...loggerMessageArgs)
       break;
     case LOGGER_LEVELS.warn:
-      console.warn(buildLoggerMessage(title, message))
+      console.warn(...loggerMessageArgs)
       break;
     case LOGGER_LEVELS.error:
-      console.error(buildLoggerMessage(title, message))
+      console.error(...loggerMessageArgs)
       break;
     default:
-      console.log(buildLoggerMessage(title, message))
+      console.log(...loggerMessageArgs)
   }
 }

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -1,11 +1,11 @@
 import {config} from "../config"
 
 export const LOGGER_LEVELS = {
-  "debug": 0,
-  "info": 1,
-  "log": 2,
-  "warn": 3,
-  "error": 4
+  "debug": 5,
+  "info": 4,
+  "log": 3,
+  "warn": 2,
+  "error": 1
 }
 
 const buildLoggerMessage = (title, message) => {
@@ -19,7 +19,7 @@ const buildLoggerMessage = (title, message) => {
 }
 
 export const logger = async (title, message, level) => {
-  const configLoggerLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
+  const configLoggerLevel =  await config.get("logger.level", 0)
 
   // If config level is below message level then don't show it
   if (configLoggerLevel < level) return

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -21,7 +21,16 @@ const buildLoggerMessage = (title, message) => {
 export const logger = async (title, message, level) => {
   const configLoggerLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
 
-  if (configLoggerLevel >= level) {
-    console.warn(buildLoggerMessage(title, message))
+  // If config level is below message level then don't show it
+  if (configLoggerLevel < level) return
+
+  switch(level) {
+    case LOGGER_LEVELS.warn:
+      console.warn(buildLoggerMessage(title, message))
+    case LOGGER_LEVELS.error:
+      console.error(buildLoggerMessage(title, message))
+      break;
+    default:
+      console.log(buildLoggerMessage(title, message))
   }
 }

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -1,0 +1,27 @@
+import {config} from "../config"
+
+export const LOGGER_LEVELS = {
+  "debug": 0,
+  "info": 1,
+  "log": 2,
+  "warn": 3,
+  "error": 4
+}
+
+const buildLoggerMessage = (title, message) => {
+  return `
+    %c${title}
+    ============================
+    ${message}
+    ============================
+    `,
+    "font-weight:bold;font-family:monospace;"
+}
+
+export const logger = async (title, message, level) => {
+  const configLoggerLevel =  await config.get("logger.level", LOGGER_LEVELS.debug)
+
+  if (configLoggerLevel >= level) {
+    console.warn(buildLoggerMessage(title, message))
+  }
+}


### PR DESCRIPTION
Addresses: https://github.com/onflow/fcl-js/issues/1046
----

This is the first step in property renamings/deprecations mentioned on the ticket above. We want to give notices to developers to change to the new names, but we first need to change our internal usage before these notices go fully live. This PR adds a way to enable warnings if a config for logger is set to the corresponding level. If a developer enables this they will see it. Once we have changed our usage internally, we can remove the logging level so that it warns any time it is used. 

It does not modify the account or interaction object. Instead, it uses a proxy to return the original properties' value if either the original property or the new property is being used. If it is the original property being used, then the warning is shown.