### PR TITLE
Docs: fix `UFix64`, `Fix64` and `Address` in types tables

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1998,16 +1998,15 @@ FCL arguments must specify one of the following support types for each value pas
 | `Word16`     | `fcl.arg(16, t.Word16)`                                                                                              |
 | `Word32`     | `fcl.arg(32, t.Word32)`                                                                                              |
 | `Word64`     | `fcl.arg(64, t.Word64)`                                                                                              |
-| `UFix64`     | `fcl.arg("64.123", t.UFix256)`                                                                                       |
-| `Fix64`      | `fcl.arg("64.123", t.Fix256)`                                                                                        |
+| `UFix64`     | `fcl.arg("64.123", t.UFix64)`                                                                                        |
+| `Fix64`      | `fcl.arg("64.123", t.Fix64)`                                                                                         |
 | `String`     | `fcl.arg("Flow", t.String)`                                                                                          |
 | `Character`  | `fcl.arg("c", t.String)`                                                                                             |
 | `Bool`       | `fcl.arg(true, t.String)`                                                                                            |
-| `Address`    | `fcl.arg("0xABC123DEF456", t.String)`                                                                                |
+| `Address`    | `fcl.arg("0xABC123DEF456", t.Address)`                                                                               |
 | `Optional`   | `fcl.arg("Flow", t.Optional(t.String))`                                                                              |
 | `Array`      | `fcl.args([ fcl.arg(["First", "Second"], t.Array(t.String)) ])`                                                      |
 | `Dictionary` | `fcl.args([fcl.arg([{key: 1, value: "one"}, {key: 2, value: "two"}], t.Dictionary({key: t.Int, value: t.String}))])` |
-
-| `Path` | `fcl.arg({ domain: "public", identifier: "flowTokenVault" }, t.Path)` |
+| `Path`       | `fcl.arg({ domain: "public", identifier: "flowTokenVault" }, t.Path)`                                                |
 
 ---


### PR DESCRIPTION
It seems that the `UFix64` and `Fix64` type arguments are not correctly
represented if you pass them as arguments with the `t.UFix256` or
`t.Fix256` type respectively.

After a quick look in [`types.js`](https://github.com/onflow/fcl-js/blob/master/packages/types/src/types.js) it seems that the library doesn't even
know about those types. Passing in `t.UFix64` and `t.Fix64` as a type
seems to work just fine.

It also seems that an `Address` typed argument needs to be passed in
with the `t.Address` type instead of the `t.String` type as suggested
in the docs.

This PR additionally fixes the formatting/styling for the `path` type
at the very end of the table in the docs.

<img src="https://user-images.githubusercontent.com/6411752/159339871-1906156c-735d-42df-8275-19f4899f8432.png" width="75%">

