### PR TITLE
DOC -- [root] Add links to the fcl-discovery repo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,13 @@ The communication channels involve responding to a set of pre-defined FCL messag
 - [Dapper Wallet](https://www.meetdapper.com/) (beta access - general availability coming soon)
 
 ### Wallet Discovery
-It can be difficult to get users to discover new wallets on a chain. To solve this, we created a wallet discovery service that can be configured and accessed through FCL to display all available Flow wallet providers to the user. This means:
+It can be difficult to get users to discover new wallets on a chain. To solve this, we created a [wallet discovery service](https://github.com/onflow/fcl-discovery) that can be configured and accessed through FCL to display all available Flow wallet providers to the user. This means:
 - Dapps can display and support all FCL compatible wallets that launch on Flow without needing to change any code
 - Users don't need to sign up for new wallets - they can carry over their existing one to any dapp that uses FCL for authentication and authorization.
 
 The discovery feature can be used via API allowing you to customize your own UI or you can use the default UI without any additional configuration.
+
+> Note: To get your wallet added to the discovery service, make a PR in [fcl-discovery](https://github.com/onflow/fcl-discovery).
 
 ### Building a FCL compatible wallet
 


### PR DESCRIPTION
Hi!

We are considering adding Flow Dapp support to our wallet, and first of all I just want to confirm that if we develop it, we will be able to just add it in https://github.com/onflow/fcl-discovery/blob/master/data/services.json. If the process is not as I described (making a PR there), but something else, let's discuss it, and I will modify this PR to include that process description in the readme.

I also had a hard time finding the `fcl-discovery` repo itself, so I think it would be useful for others as well to link it here.
