### PR TITLE
PKG -- [transport-http] Preference `fetch` over `window?.fetch`

### DIFF
--- a/packages/transport-http/src/http-request.js
+++ b/packages/transport-http/src/http-request.js
@@ -44,7 +44,7 @@ export async function httpRequest({
 
   let fetchTransport
   try {
-    fetchTransport = window?.fetch || fetch
+    fetchTransport = fetch || window?.fetch
   } catch (e) {}
 
   const {


### PR DESCRIPTION
Fix a bug that causes `fetchTransport` to be undefined in environments where `fetch` is defined but `window` isn't (e.g. Cloudflare Workers)

Resolves #1089