### PR TITLE
PKG -- [sdk] Makes @onflow/transport-http the default send module used by sdk

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- 2022-03-28 -- **BREAKING** [@JeffreyDoyle](https://github.com/JeffreyDoyle): Makes `@onflow/transport-http` the default send module used by SDK. By default, SDK will need to be configured with `accessNode.api` corresponding to a REST/HTTP access node, unless another send module is configured.
 - 2022-03-16 -- [@bthaile](https://github.com/bthaile) Payer can now be an array of keys on a single account. Non-array payer is deprecated and will error in future versions of sdk. 
 - 2022-03-16 -- [@chasefleming](https://github.com/chasefleming): Warn about field renamings/deprecations. To turn on warnings, set config `log.level` to `2`.
 
@@ -24,7 +25,7 @@ await sdk.account("0x123", {height: 123}) // New: get account at the block with 
 
 ## 0.0.57-alpha.1 -- 2022-01-21
 
-- 2022-01-21 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Abstracts away the SDK transport modules into their own packages. The JS-SDK now makes use of transport modules for sending an interaction to an access api and receiving a response. A transport module must be defined in config:
+- 2022-01-21 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Abstracts away the SDK transport modules into their own packages. The JS-SDK now makes use of transport modules for sending an interaction to an access api and receiving a response. A transport module can be defined in config:
 
 ```javascript
 import {send as grpcSend} from "@onflow/transport-grpc"

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@onflow/rlp": "^0.0.3",
+        "@onflow/transport-http": "^0.0.6",
         "@onflow/util-actor": "0.0.2",
         "@onflow/util-address": "^0.0.0",
         "@onflow/util-invariant": "^0.0.0",
@@ -1078,6 +1079,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@onflow/rlp/-/rlp-0.0.3.tgz",
       "integrity": "sha512-oAf0VEiMjX8eC6Vd66j1BdGYTHOM6UBaS/sLSScnc7bKX5gICqe2gtEsCeJVE9rUzRk3GD3JqXRnPAW6YFWd/Q=="
+    },
+    "node_modules/@onflow/transport-http": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@onflow/transport-http/-/transport-http-0.0.6.tgz",
+      "integrity": "sha512-KOmA6h00O3EARMd+mW6wkxnKgJvjHt2KdXJzeCczgf/LOxXYIAFagbaJtJt3ljwCnIYQRjm6iy2YZutehg6cHw==",
+      "dependencies": {
+        "@onflow/util-address": "^0.0.0",
+        "@onflow/util-invariant": "^0.0.0",
+        "@onflow/util-template": "0.0.1"
+      }
     },
     "node_modules/@onflow/util-actor": {
       "version": "0.0.2",
@@ -6287,6 +6298,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@onflow/rlp/-/rlp-0.0.3.tgz",
       "integrity": "sha512-oAf0VEiMjX8eC6Vd66j1BdGYTHOM6UBaS/sLSScnc7bKX5gICqe2gtEsCeJVE9rUzRk3GD3JqXRnPAW6YFWd/Q=="
+    },
+    "@onflow/transport-http": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@onflow/transport-http/-/transport-http-0.0.6.tgz",
+      "integrity": "sha512-KOmA6h00O3EARMd+mW6wkxnKgJvjHt2KdXJzeCczgf/LOxXYIAFagbaJtJt3ljwCnIYQRjm6iy2YZutehg6cHw==",
+      "requires": {
+        "@onflow/util-address": "^0.0.0",
+        "@onflow/util-invariant": "^0.0.0",
+        "@onflow/util-template": "0.0.1"
+      }
     },
     "@onflow/util-actor": {
       "version": "0.0.2",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@onflow/rlp": "^0.0.3",
+    "@onflow/transport-http": "^0.0.6",
     "@onflow/util-actor": "0.0.2",
     "@onflow/util-address": "^0.0.0",
     "@onflow/util-invariant": "^0.0.0",

--- a/packages/sdk/src/resolve/resolve-proposer-sequence-number.js
+++ b/packages/sdk/src/resolve/resolve-proposer-sequence-number.js
@@ -7,13 +7,15 @@ import {getAccount} from "../build/build-get-account.js"
 import {build} from "../build/build.js"
 import {invariant} from "@onflow/util-invariant"
 import {Buffer} from "@onflow/rlp"
+import {send as defaultSend} from "@onflow/transport-http"
 
 export const resolveProposerSequenceNumber = ({ node }) => async (ix) => {
   if (!(isTransaction(ix))) return Ok(ix)
   if (ix.accounts[ix.proposer].sequenceNum) return Ok(ix)
 
   const sendFn = await config.first(
-    ["sdk.transport", "sdk.send"]
+    ["sdk.transport", "sdk.send"],
+    defaultSend
   )
 
   invariant(

--- a/packages/sdk/src/resolve/resolve-ref-block-id.js
+++ b/packages/sdk/src/resolve/resolve-ref-block-id.js
@@ -6,11 +6,13 @@ import {decodeResponse} from "../decode/decode.js"
 import {getBlock} from "../build/build-get-block.js"
 import {invariant} from "@onflow/util-invariant"
 import {Buffer} from "@onflow/rlp"
+import {send as defaultSend} from "@onflow/transport-http"
 
 async function getRefId (opts) {
   const node = await config().get("accessNode.api")
   const sendFn = await config.first(
-    ["sdk.transport", "sdk.send"]
+    ["sdk.transport", "sdk.send"],
+    defaultSend
   )
 
   invariant(

--- a/packages/sdk/src/resolve/resolve.js
+++ b/packages/sdk/src/resolve/resolve.js
@@ -2,6 +2,7 @@ import {pipe, isTransaction} from "../interaction/interaction.js"
 import {config} from "../config"
 import {invariant} from "@onflow/util-invariant"
 import {Buffer} from "@onflow/rlp"
+import {send as defaultSend} from "@onflow/transport-http"
 import * as ixModule from "../interaction/interaction.js"
 import {response} from "../response/response.js"
 import {build} from "../build/build.js"
@@ -67,7 +68,7 @@ export const resolve = pipe([
 async function execFetchRef(ix) {
   if (isTransaction(ix) && ix.message.refBlock == null) {
     const node = await config().get("accessNode.api")
-    const sendFn = await config.first(["sdk.transport", "sdk.send"])
+    const sendFn = await config.first(["sdk.transport", "sdk.send"], defaultSend)
 
     invariant(
       sendFn,
@@ -91,7 +92,7 @@ async function execFetchSequenceNumber(ix) {
     invariant(acct, `Transactions require a proposer`)
     if (acct.sequenceNum == null) {
       const node = await config().get("accessNode.api")
-      const sendFn = await config.first(["sdk.transport", "sdk.send"])
+      const sendFn = await config.first(["sdk.transport", "sdk.send"], defaultSend)
 
       invariant(
         sendFn,

--- a/packages/sdk/src/send/send.js
+++ b/packages/sdk/src/send/send.js
@@ -1,4 +1,5 @@
 import {Buffer} from "@onflow/rlp"
+import {send as defaultSend} from "@onflow/transport-http"
 import {interaction, pipe} from "../interaction/interaction.js"
 import * as ixModule from "../interaction/interaction.js"
 import {invariant} from "../build/build-invariant.js"
@@ -9,7 +10,7 @@ import {resolve as defaultResolve} from "../resolve/resolve.js"
 export const send = async (args = [], opts = {}) => {
   const sendFn = await config.first(
     ["sdk.transport", "sdk.send"],
-    opts.send
+    opts.send || defaultSend
   )
 
   invariant(


### PR DESCRIPTION
### Addresses https://github.com/onflow/fcl-js/issues/1082

PKG -- [sdk] Makes @onflow/transport-http the default send module used by sdk