### PR TITLE
[fcl] Move verifyUserSignatures to AppUtils

### DIFF
--- a/.changeset/heavy-cats-draw.md
+++ b/.changeset/heavy-cats-draw.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": minor
+---
+
+Import Buffer from rlp in encode-account-proof

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -790,7 +790,9 @@ const txId = await fcl.mutate({
 
 ---
 
-## `verifyUserSignatures`
+## `verifyUserSignatures` (Deprecated)
+
+Use `fcl.AppUtils.verifyUserSignatures`
 
 A method allowing applications to cryptographically verify the ownership of a Flow account by verifying a message was signed by a user's private key/s. This is typically used with the response from `currentUser.signUserMessage`.
 
@@ -814,7 +816,7 @@ import * as fcl from "@onflow/fcl"
 
 const verifySignatures = async (message, compositeSignatures) => {
   try {
-    return await verifyUserSignatures(message, compositeSignatures)
+    return await fcl.AppUtils.verifyUserSignatures(message, compositeSignatures)
   } catch (error) {
     console.log(error)
   }
@@ -824,8 +826,6 @@ const verifySignatures = async (message, compositeSignatures) => {
 #### Examples
 
 Use cases include cryptographic login, message validation, verifiable credentials, and others.
-
-- [Cryptographic Login Example (coming soon)](#)
 
 ---
 

--- a/packages/fcl/src/app-utils/__tests__/verify-user-sig.test.js
+++ b/packages/fcl/src/app-utils/__tests__/verify-user-sig.test.js
@@ -1,4 +1,4 @@
-import {verifyUserSignatures, validateArgs} from "../verify"
+import {verifyUserSignatures, validateArgs} from "../verify-user-signatures"
 
 const message = Buffer.from("FOO").toString("hex")
 

--- a/packages/fcl/src/app-utils/index.js
+++ b/packages/fcl/src/app-utils/index.js
@@ -1,1 +1,2 @@
 export {verifyAccountProof} from "./verify-account-proof.js"
+export {verifyUserSignatures} from "./verify-user-signatures.js"

--- a/packages/fcl/src/app-utils/verify-account-proof.js
+++ b/packages/fcl/src/app-utils/verify-account-proof.js
@@ -78,7 +78,7 @@ export async function verifyAccountProof(
     `
   }
 
-  return await query({
+  return query({
     cadence: await getVerifyAccountProofSignaturesScript(),
     args: (arg, t) => [
       arg(address, t.Address),

--- a/packages/fcl/src/app-utils/verify-account-proof.js
+++ b/packages/fcl/src/app-utils/verify-account-proof.js
@@ -36,7 +36,7 @@ export const validateArgs = (appIdentifier, address, nonce, signatures) => {
  *   signatures: [{f_type: "CompositeSignature", f_vsn: "1.0.0", addr: "0x123", keyId: 0, signature: "abc123"}],
  *  }
  *
- *  const isValid = await fcl.verifyAccountProof(
+ *  const isValid = await fcl.AppUtils.verifyAccountProof(
  *    "AwesomeAppId",
  *    accountProofData,
  *  )

--- a/packages/fcl/src/app-utils/verify-user-signatures.js
+++ b/packages/fcl/src/app-utils/verify-user-signatures.js
@@ -1,0 +1,77 @@
+import {invariant} from "@onflow/util-invariant"
+import {query} from "../exec/query"
+import {config} from "@onflow/sdk"
+
+export const validateArgs = (msg, compSigs) => {
+  invariant(/^[0-9a-f]+$/i.test(msg), "Signed message must be a hex string")
+  invariant(
+    Array.isArray(compSigs) &&
+      compSigs.every((sig, i, arr) => sig.f_type === "CompositeSignature"),
+    "Must include an Array of CompositeSignatures to verify"
+  )
+  invariant(
+    compSigs.map(cs => cs.addr).every((addr, i, arr) => addr === arr[0]),
+    "User signatures to be verified must be from a single account address"
+  )
+  return true
+}
+
+/**
+ * Verify a valid signature/s for an account on Flow.
+ *
+ * @param {string} msg - A message string in hexadecimal format
+ * @param {Array} compSigs - An array of Composite Signatures
+ * @param {string} compSigs[].addr - The account address
+ * @param {number} compSigs[].keyId - The account keyId
+ * @param {string} compSigs[].signature - The signature to verify
+ * @return {bool}
+ *
+ * @example
+ *
+ *  const isValid = await fcl.AppUtils.verifyUserSignatures(
+ *    Buffer.from('FOO').toString("hex"),
+ *    [{f_type: "CompositeSignature", f_vsn: "1.0.0", addr: "0x123", keyId: 0, signature: "abc123"}]
+ *  )
+ */
+export async function verifyUserSignatures(message, compSigs) {
+  validateArgs(message, compSigs)
+
+  const address = compSigs[0].addr
+  let signaturesArr = []
+  let keyIndices = []
+
+  for (const el of compSigs) {
+    signaturesArr.push(el.signature)
+    keyIndices.push(el.keyId)
+  }
+
+  const getVerifyUserSignaturesScript = async () => {
+    const contractAddress =
+      (await config.get("env")) === "testnet"
+        ? "0x74daa6f9c7ef24b1"
+        : "0xb4b82a1c9d21d284"
+
+    return `
+      import FCLCrypto from ${contractAddress}
+
+      pub fun main(
+          address: Address, 
+          message: String, 
+          keyIndices: [Int], 
+          signatures: [String]
+      ): Bool {
+        return FCLCrypto.verifyUserSignatures(address: address, message: message, keyIndices: keyIndices, signatures: signatures)
+      }
+    `
+  }
+
+  return query({
+    cadence: await getVerifyUserSignaturesScript(),
+    args: (arg, t) => [
+      arg(address, t.Address),
+      arg(message, t.String),
+      arg(keyIndices, t.Array([t.Int])),
+      arg(signaturesArr, t.Array([t.String])),
+    ],
+  })
+}

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -7,7 +7,6 @@ import {invariant} from "@onflow/util-invariant"
 import {buildUser} from "./build-user"
 import {serviceOfType} from "./service-of-type"
 import {execService} from "./exec-service"
-import {verifyUserSignatures as verify} from "../exec/verify"
 import {normalizeCompositeSignature} from "./normalize/composite-signature"
 import {getDiscoveryService} from "../config-utils"
 
@@ -330,28 +329,12 @@ async function signUserMessage(msg) {
   }
 }
 
-// Deprecated
-async function verifyUserSignatures(msg, compSigs) {
-  console.warn(
-    `
-    %cFCL/SDK Deprecation Notice
-    ============================
-    verifyUserSignatures is no longer exported as fcl.currentUser().verifyUserSignatures
-    and is now available as fcl.verifyUserSignatures
-    ============================
-    `,
-    "font-weight:bold;font-family:monospace;"
-  )
-  return verify(msg, compSigs)
-}
-
 let currentUser = () => {
   return {
     authenticate,
     unauthenticate,
     authorization,
     signUserMessage,
-    verifyUserSignatures,
     subscribe,
     snapshot,
     resolveArgument,
@@ -362,7 +345,6 @@ currentUser.authenticate = authenticate
 currentUser.unauthenticate = unauthenticate
 currentUser.authorization = authorization
 currentUser.signUserMessage = signUserMessage
-currentUser.verifyUserSignatures = verifyUserSignatures
 currentUser.subscribe = subscribe
 currentUser.snapshot = snapshot
 currentUser.resolveArgument = resolveArgument

--- a/packages/fcl/src/exec/verify.js
+++ b/packages/fcl/src/exec/verify.js
@@ -1,23 +1,9 @@
-import {invariant} from "@onflow/util-invariant"
-import {query} from "../exec/query"
-import {config} from "@onflow/sdk"
-
-export const validateArgs = (msg, compSigs) => {
-  invariant(/^[0-9a-f]+$/i.test(msg), "Signed message must be a hex string")
-  invariant(
-    Array.isArray(compSigs) &&
-      compSigs.every((sig, i, arr) => sig.f_type === "CompositeSignature"),
-    "Must include an Array of CompositeSignatures to verify"
-  )
-  invariant(
-    compSigs.map(cs => cs.addr).every((addr, i, arr) => addr === arr[0]),
-    "User signatures to be verified must be from a single account address"
-  )
-  return true
-}
+import {verifyUserSignatures as verify} from "../app-utils"
 
 /**
  * Verify a valid signature/s for an account on Flow.
+ *
+ * @deprecated since version '1.0.0-alpha.0'
  *
  * @param {string} msg - A message string in hexadecimal format
  * @param {Array} compSigs - An array of Composite Signatures
@@ -34,44 +20,15 @@ export const validateArgs = (msg, compSigs) => {
  *  )
  */
 export async function verifyUserSignatures(message, compSigs) {
-  validateArgs(message, compSigs)
-
-  const address = compSigs[0].addr
-  let signaturesArr = []
-  let keyIndices = []
-
-  for (const el of compSigs) {
-    signaturesArr.push(el.signature)
-    keyIndices.push(el.keyId)
-  }
-
-  const getVerifyUserSignaturesScript = async () => {
-    const contractAddress =
-      (await config.get("env")) === "testnet"
-        ? "0x74daa6f9c7ef24b1"
-        : "0xb4b82a1c9d21d284"
-
-    return `
-      import FCLCrypto from ${contractAddress}
-
-      pub fun main(
-          address: Address, 
-          message: String, 
-          keyIndices: [Int], 
-          signatures: [String]
-      ): Bool {
-        return FCLCrypto.verifyUserSignatures(address: address, message: message, keyIndices: keyIndices, signatures: signatures)
-      }
+  console.warn(
     `
-  }
-
-  return await query({
-    cadence: await getVerifyUserSignaturesScript(),
-    args: (arg, t) => [
-      arg(address, t.Address),
-      arg(message, t.String),
-      arg(keyIndices, t.Array([t.Int])),
-      arg(signaturesArr, t.Array([t.String])),
-    ],
-  })
+    %cFCL/SDK Deprecation Notice
+    ============================
+    fcl.verifyUserSignatures() is deprecated and will be removed in a future release
+    Please use fcl.AppUtils.verifyUserSignatures()
+    ============================
+    `,
+    "font-weight:bold;font-family:monospace;"
+  )
+  return verify(message, compSigs)
 }

--- a/packages/fcl/src/exec/verify.js
+++ b/packages/fcl/src/exec/verify.js
@@ -1,34 +1,20 @@
 import {verifyUserSignatures as verify} from "../app-utils"
+import {deprecate} from "../utils/deprecate"
 
 /**
  * Verify a valid signature/s for an account on Flow.
  *
- * @deprecated since version '1.0.0-alpha.0'
+ * @deprecated since version '1.0.0-alpha.0', use AppUtils.verifyUserSignatures instead
  *
- * @param {string} msg - A message string in hexadecimal format
- * @param {Array} compSigs - An array of Composite Signatures
- * @param {string} compSigs[].addr - The account address
- * @param {number} compSigs[].keyId - The account keyId
- * @param {string} compSigs[].signature - The signature to verify
- * @return {bool}
- *
- * @example
- *
- *  const isValid = await fcl.verifyUserSignatures(
- *    Buffer.from('FOO').toString("hex"),
- *    [{f_type: "CompositeSignature", f_vsn: "1.0.0", addr: "0x123", keyId: 0, signature: "abc123"}]
- *  )
  */
 export async function verifyUserSignatures(message, compSigs) {
-  console.warn(
-    `
-    %cFCL/SDK Deprecation Notice
-    ============================
+  deprecate({
+    title: "FCL Deprecation Notice",
+    message: `
     fcl.verifyUserSignatures() is deprecated and will be removed in a future release
-    Please use fcl.AppUtils.verifyUserSignatures()
-    ============================
-    `,
-    "font-weight:bold;font-family:monospace;"
-  )
+    Please use fcl.AppUtils.verifyUserSignatures()`,
+    level: 2,
+    always: true,
+  })
   return verify(message, compSigs)
 }

--- a/packages/fcl/src/utils/deprecate.js
+++ b/packages/fcl/src/utils/deprecate.js
@@ -1,0 +1,5 @@
+import * as logger from "@onflow/util-logger"
+
+export const deprecate = async ({title, message, level, always}) => {
+  await logger.log({title, message, level, always})
+}

--- a/packages/fcl/src/utils/index.js
+++ b/packages/fcl/src/utils/index.js
@@ -1,0 +1,1 @@
+export {deprecate} from "./deprecate.js"

--- a/packages/fcl/src/wallet-utils/encode-account-proof.js
+++ b/packages/fcl/src/wallet-utils/encode-account-proof.js
@@ -1,6 +1,6 @@
 import {sansPrefix} from "@onflow/util-address"
 import {invariant} from "@onflow/util-invariant"
-import {encode as rlpEncode} from "@onflow/rlp"
+import {Buffer, encode as rlpEncode} from "@onflow/rlp"
 
 const rightPaddedHexBuffer = (value, pad) =>
   Buffer.from(value.padEnd(pad * 2, 0), "hex")


### PR DESCRIPTION
### Moves `verifyUserSignatures` to `AppUtils` namespace

- Remove deprecated `currentUser.verifyUserSignatures`
- Deprecate `fcl.verifyUserSignatures`
- Update api reference doc