### PR TITLE
[fcl] Remove window.extensions from service msg

### DIFF
--- a/.changeset/good-cougars-impress.md
+++ b/.changeset/good-cougars-impress.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Remove window.extensions from service msg

--- a/packages/fcl/src/current-user/exec-service/index.js
+++ b/packages/fcl/src/current-user/exec-service/index.js
@@ -17,7 +17,6 @@ const STRATEGIES = {
 }
 
 export async function execService({service, msg = {}, opts = {}, config = {}}) {
-  msg.extensions = window.fcl_extensions || []
   msg.data = service.data
   const fullConfig = {
     ...config,


### PR DESCRIPTION
### Remove window.extensions from service msg

In execService, removes adding window.extensions on msg passed to Discovery.
This is now added to `config`