### PR TITLE
export LOCAL_STORAGE const

### DIFF
--- a/packages/fcl/src/config-utils.js
+++ b/packages/fcl/src/config-utils.js
@@ -9,7 +9,7 @@ const SESSION_STORAGE = {
   put: async (key, value) => sessionStorage.setItem(key, JSON.stringify(value)),
 }
 
-const LOCAL_STORAGE = {
+export const LOCAL_STORAGE = {
   can: !isServerSide(),
   get: async key => JSON.parse(localStorage.getItem(key)),
   put: async (key, value) => localStorage.setItem(key, JSON.stringify(value)),


### PR DESCRIPTION
Currently there is a way to inject the use of local storage into fcl so that logins persist across tabs, but the const that enables this easily (no custom code by the consumer) isn't exported