### PR TITLE
OPS -- Add '--no-compress' to watch scripts

### DIFF
--- a/.changeset/rotten-news-scream.md
+++ b/.changeset/rotten-news-scream.md
@@ -1,0 +1,19 @@
+---
+"@onflow/config": minor
+"@onflow/fcl": minor
+"@onflow/rlp": minor
+"@onflow/sdk": minor
+"@onflow/transport-grpc": minor
+"@onflow/transport-http": minor
+"@onflow/types": minor
+"@onflow/util-actor": minor
+"@onflow/util-address": minor
+"@onflow/util-encode-key": minor
+"@onflow/util-invariant": minor
+"@onflow/util-logger": minor
+"@onflow/util-node-http-modules": minor
+"@onflow/util-template": minor
+"@onflow/util-uid": minor
+---
+
+Add --no-compress to watch scripts for easier debugging

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,7 +31,7 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   },
   "dependencies": {
     "@onflow/util-actor": "^1.0.0"

--- a/packages/fcl/package.json
+++ b/packages/fcl/package.json
@@ -38,7 +38,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "build": "microbundle --no-compress --define MICROBUNDLE_CURRENT_VERSION=$npm_package_version",
-    "start": "microbundle watch --define MICROBUNDLE_CURRENT_VERSION=$npm_package_version"
+    "start": "microbundle watch --define MICROBUNDLE_CURRENT_VERSION=$npm_package_version --no-compress"
   },
   "dependencies": {
     "@onflow/config": "^1.0.0",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -31,7 +31,7 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   },
   "dependencies": {
     "buffer": "^6.0.3"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,7 +36,7 @@
     "build": "microbundle --no-compress --define MICROBUNDLE_CURRENT_VERSION=$npm_package_version",
     "currentVersion": "node -e MICROBUNDLE_CURRENT_VERSION=$npm_package_version",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle --no-compress --define MICROBUNDLE_CURRENT_VERSION=$npm_package_version watch"
   },
   "dependencies": {
     "@onflow/config": "^1.0.0",

--- a/packages/transport-grpc/package.json
+++ b/packages/transport-grpc/package.json
@@ -32,7 +32,7 @@
         "test": "jest",
         "build": "microbundle --no-compress",
         "test:watch": "jest --watch",
-        "start": "microbundle watch"
+        "start": "microbundle watch --no-compress"
     },
     "dependencies": {
         "@improbable-eng/grpc-web": "^0.14.0",

--- a/packages/transport-http/package.json
+++ b/packages/transport-http/package.json
@@ -34,7 +34,7 @@
         "test": "jest",
         "build": "microbundle --no-compress",
         "test:watch": "jest --watch",
-        "start": "microbundle watch"
+        "start": "microbundle watch --no-compress"
     },
     "dependencies": {
         "@onflow/util-address": "^1.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,6 +31,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }

--- a/packages/util-actor/package.json
+++ b/packages/util-actor/package.json
@@ -34,6 +34,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }

--- a/packages/util-address/package.json
+++ b/packages/util-address/package.json
@@ -32,6 +32,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }

--- a/packages/util-encode-key/package.json
+++ b/packages/util-encode-key/package.json
@@ -32,7 +32,7 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   },
   "dependencies": {
     "@onflow/rlp": "^1.0.0",

--- a/packages/util-invariant/package.json
+++ b/packages/util-invariant/package.json
@@ -32,6 +32,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }

--- a/packages/util-logger/package.json
+++ b/packages/util-logger/package.json
@@ -31,7 +31,7 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   },
   "dependencies": {
     "@onflow/sdk": "^1.0.0"

--- a/packages/util-node-http-modules/package.json
+++ b/packages/util-node-http-modules/package.json
@@ -36,7 +36,7 @@
         "test": "jest",
         "build": "microbundle --no-compress",
         "test:watch": "jest --watch",
-        "start": "microbundle watch"
+        "start": "microbundle watch --no-compress"
     },
     "dependencies": {}
 }

--- a/packages/util-template/package.json
+++ b/packages/util-template/package.json
@@ -31,6 +31,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }

--- a/packages/util-uid/package.json
+++ b/packages/util-uid/package.json
@@ -31,6 +31,6 @@
     "test": "jest",
     "build": "microbundle --no-compress",
     "test:watch": "jest --watch",
-    "start": "microbundle watch"
+    "start": "microbundle watch --no-compress"
   }
 }


### PR DESCRIPTION
Watch scripts were still compressing.  Easier to debug non-minified files. `--define MICROBUNDLE_CURRENT_VERSION=$npm_package_version` was missing altogether from @onflow/fcl watch script and was required to run `npm run watch`