### PR TITLE
PKG -- [fcl] Handle network disconnect in transaction subscriber

### DIFF
--- a/.changeset/nasty-actors-sing.md
+++ b/.changeset/nasty-actors-sing.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Added exception handling in transaction subscriber polling to handle network disconnect/server error events

--- a/packages/fcl/src/transaction/index.js
+++ b/packages/fcl/src/transaction/index.js
@@ -47,7 +47,14 @@ const HANDLERS = {
     letter.reply(ctx.all())
   },
   [POLL]: async ctx => {
-    const tx = await fetchTxStatus(ctx.self())
+    let tx
+    try {
+      tx = await fetchTxStatus(ctx.self())
+    } catch (e) {
+      console.error(e)
+      setTimeout(() => ctx.sendSelf(POLL), RATE)
+      return
+    }
     if (!isSealed(tx)) setTimeout(() => ctx.sendSelf(POLL), RATE)
     if (isDiff(ctx.all(), tx)) ctx.broadcast(UPDATED, tx)
     ctx.merge(tx)


### PR DESCRIPTION
This was being caused by unhandled network exception in the POLL handler for the transaction subscriber.  When this exception was thrown (i.e. server error, user network disconnect on shoddy network perhaps *potential issue for those on mobile networks*), it would abort the POLL handler prior to `setTImeout(() => ctx.sendSelf(POLL), RATE)` being called, effectively ending the POLL prematurely.

This may be a recurring issue with actors that likely follow the same pattern and stop polling after a single unhandled exception.