### PR TITLE
PKG -- [transport-http] Add status code to transaction status

### DIFF
--- a/.changeset/chilled-vans-happen.md
+++ b/.changeset/chilled-vans-happen.md
@@ -1,0 +1,5 @@
+---
+"@onflow/transport-http": minor
+---
+
+Added `statusCode` to `transactionStatus` (previously always 0)

--- a/packages/transport-http/src/send-get-transaction-status.js
+++ b/packages/transport-http/src/send-get-transaction-status.js
@@ -2,18 +2,27 @@ import {invariant} from "@onflow/util-invariant"
 import {httpRequest as defaultHttpRequest} from "./http-request.js"
 
 const STATUS_MAP = {
-  "UNKNOWN": 0,
-  "PENDING": 1,
-  "FINALIZED": 2,
-  "EXECUTED": 3,
-  "SEALED": 4,
-  "EXPIRED": 5
+  UNKNOWN: 0,
+  PENDING: 1,
+  FINALIZED: 2,
+  EXECUTED: 3,
+  SEALED: 4,
+  EXPIRED: 5,
 }
 
 export async function sendGetTransactionStatus(ix, context = {}, opts = {}) {
-  invariant(opts.node, `SDK Send Get Transaction Status Error: opts.node must be defined.`)
-  invariant(context.response, `SDK Send Get Transaction Status Error: context.response must be defined.`)
-  invariant(context.Buffer, `SDK Send Get Transaction Status Error: context.Buffer must be defined.`)
+  invariant(
+    opts.node,
+    `SDK Send Get Transaction Status Error: opts.node must be defined.`
+  )
+  invariant(
+    context.response,
+    `SDK Send Get Transaction Status Error: context.response must be defined.`
+  )
+  invariant(
+    context.Buffer,
+    `SDK Send Get Transaction Status Error: context.Buffer must be defined.`
+  )
 
   const httpRequest = opts.httpRequest || defaultHttpRequest
 
@@ -23,24 +32,26 @@ export async function sendGetTransactionStatus(ix, context = {}, opts = {}) {
     hostname: opts.node,
     path: `/v1/transaction_results/${ix.transaction.id}`,
     method: "GET",
-    body: null
+    body: null,
   })
 
   let ret = context.response()
   ret.tag = ix.tag
   ret.transactionStatus = {
     blockId: res.block_id,
-    status: STATUS_MAP[res.status.toUpperCase()] || "", 
-    statusString: res.status.toUpperCase(), 
-    statusCode: 0, // TODO: Use field when it becomes available on HTTP Access API
+    status: STATUS_MAP[res.status.toUpperCase()] || "",
+    statusString: res.status.toUpperCase(),
+    statusCode: res.status_code,
     errorMessage: res.error_message,
     events: res.events.map(event => ({
       type: event.type,
       transactionId: event.transaction_id,
       transactionIndex: Number(event.transaction_index),
       eventIndex: Number(event.event_index),
-      payload: JSON.parse(context.Buffer.from(event.payload, "base64").toString())
-    }))
+      payload: JSON.parse(
+        context.Buffer.from(event.payload, "base64").toString()
+      ),
+    })),
   }
 
   return ret

--- a/packages/transport-http/src/send-get-transaction-status.test.js
+++ b/packages/transport-http/src/send-get-transaction-status.test.js
@@ -7,41 +7,40 @@ import {Buffer} from "@onflow/rlp"
 
 describe("Get Transaction Status", () => {
   test("GetTransactionResult", async () => {
-    const httpRequestMock = jest.fn();
+    const httpRequestMock = jest.fn()
 
     const returnedTransactionStatus = {
-        blockId: "abc123",
-        status: "Pending",
-        error_message: "No Error",
-        computation_used: "100",
-        block_id: "abc123",
-        events: [
-            {
-                type: "MyEvent",
-                transaction_id: "a1b2c3",
-                transaction_index: "123",
-                event_index: "456",
-                payload: Buffer.from(JSON.stringify({type: "String", value: "Hello, Flow"})).toString("base64")
-            }
-        ]
+      blockId: "abc123",
+      status: "Pending",
+      status_code: 0,
+      error_message: "No Error",
+      computation_used: "100",
+      block_id: "abc123",
+      events: [
+        {
+          type: "MyEvent",
+          transaction_id: "a1b2c3",
+          transaction_index: "123",
+          event_index: "456",
+          payload: Buffer.from(
+            JSON.stringify({type: "String", value: "Hello, Flow"})
+          ).toString("base64"),
+        },
+      ],
     }
 
-    httpRequestMock.mockReturnValue(returnedTransactionStatus);
+    httpRequestMock.mockReturnValue(returnedTransactionStatus)
 
     const response = await sendGetTransactionStatus(
-        await resolve(
-            await build([
-                getTransactionStatus("MyTxID"),
-            ])
-        ),
-        {
-            response: responseADT,
-            Buffer,
-        },
-        {
-            httpRequest: httpRequestMock,
-            node: "localhost"
-        }
+      await resolve(await build([getTransactionStatus("MyTxID")])),
+      {
+        response: responseADT,
+        Buffer,
+      },
+      {
+        httpRequest: httpRequestMock,
+        node: "localhost",
+      }
     )
 
     expect(httpRequestMock.mock.calls.length).toEqual(1)
@@ -53,28 +52,27 @@ describe("Get Transaction Status", () => {
     const valueSent = httpRequestMock.mock.calls[0][0]
 
     expect(valueSent).toEqual({
-        hostname: "localhost",
-        path: "/v1/transaction_results/MyTxID",
-        method: "GET",
-        body: null
+      hostname: "localhost",
+      path: "/v1/transaction_results/MyTxID",
+      method: "GET",
+      body: null,
     })
 
     expect(response.transactionStatus).toStrictEqual({
-        blockId: "abc123",
-        status: 1,
-        statusString: "PENDING",
-        statusCode: 0,
-        errorMessage: "No Error",
-        events: [
-            {
-                type: "MyEvent",
-                transactionId: "a1b2c3",
-                transactionIndex: 123,
-                eventIndex: 456,
-                payload: {type: "String", value: "Hello, Flow"}
-            }
-        ]
+      blockId: "abc123",
+      status: 1,
+      statusString: "PENDING",
+      statusCode: 0,
+      errorMessage: "No Error",
+      events: [
+        {
+          type: "MyEvent",
+          transactionId: "a1b2c3",
+          transactionIndex: 123,
+          eventIndex: 456,
+          payload: {type: "String", value: "Hello, Flow"},
+        },
+      ],
     })
   })
-
 })


### PR DESCRIPTION
Changed 1 line of code and started using status_code from http response for transaction status polling.  Was marked as a TODO for when the HTTP API supported it.  Prettier butchered the file.