### PR TITLE
[fcl] - Update event listeners

### DIFF
--- a/.changeset/itchy-pumpkins-dream.md
+++ b/.changeset/itchy-pumpkins-dream.md
@@ -1,0 +1,6 @@
+---
+"@onflow/fcl": patch
+---
+
+Update event listeners in strategies
+Fixes a bug where event listener was not being removed on close

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/extension.js
@@ -10,10 +10,14 @@ export function extension(service, opts = {}) {
   const onReady = opts.onReady || noop
   const onResponse = opts.onResponse || noop
 
-  window.addEventListener(
-    "message",
-    buildMessageHandler({close, send, onReady, onResponse, onMessage})
-  )
+  const handler = buildMessageHandler({
+    close,
+    send,
+    onReady,
+    onResponse,
+    onMessage,
+  })
+  window.addEventListener("message", handler)
 
   send({service})
 
@@ -21,7 +25,7 @@ export function extension(service, opts = {}) {
 
   function close() {
     try {
-      window.removeEventListener("message", buildMessageHandler)
+      window.removeEventListener("message", handler)
       onClose()
     } catch (error) {
       console.error("Ext Close Error", error)

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/frame.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/frame.js
@@ -20,7 +20,7 @@ export function frame(service, opts = {}) {
     onMessage,
   })
   window.addEventListener("message", handler)
-  
+
   const [$frame, unmount] = renderFrame(serviceEndpoint(service))
   return {send, close}
 

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/frame.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/frame.js
@@ -12,16 +12,21 @@ export function frame(service, opts = {}) {
   const onReady = opts.onReady || noop
   const onResponse = opts.onResponse || noop
 
-  window.addEventListener(
-    "message",
-    buildMessageHandler({close, send, onReady, onResponse, onMessage})
-  )
+  const handler = buildMessageHandler({
+    close,
+    send,
+    onReady,
+    onResponse,
+    onMessage,
+  })
+  window.addEventListener("message", handler)
+  
   const [$frame, unmount] = renderFrame(serviceEndpoint(service))
   return {send, close}
 
   function close() {
     try {
-      window.removeEventListener("message", buildMessageHandler)
+      window.removeEventListener("message", handler)
       unmount()
       onClose()
     } catch (error) {

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
@@ -12,12 +12,18 @@ export function pop(service, opts = {}) {
   const onReady = opts.onReady || noop
   const onResponse = opts.onResponse || noop
 
-  window.addEventListener(
-    "message",
-    buildMessageHandler({close, send, onReady, onResponse, onMessage})
-  )
+  const handler = buildMessageHandler({
+    close,
+    send,
+    onReady,
+    onResponse,
+    onMessage,
+  })
+  window.addEventListener("message", handler)
+
   const [$pop, unmount] = renderPop(serviceEndpoint(service))
-  const timer = setInterval(function () {
+
+  const timer = setInterval(function() {
     if ($pop && $pop.closed) {
       close()
     }
@@ -27,7 +33,7 @@ export function pop(service, opts = {}) {
 
   function close() {
     try {
-      window.removeEventListener("message", buildMessageHandler)
+      window.removeEventListener("message", handler)
       clearInterval(timer)
       unmount()
       onClose()

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
@@ -23,7 +23,7 @@ export function pop(service, opts = {}) {
 
   const [$pop, unmount] = renderPop(serviceEndpoint(service))
 
-  const timer = setInterval(function() {
+  const timer = setInterval(function () {
     if ($pop && $pop.closed) {
       close()
     }

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/tab.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/tab.js
@@ -12,12 +12,17 @@ export function tab(service, opts = {}) {
   const onReady = opts.onReady || noop
   const onResponse = opts.onResponse || noop
 
-  window.addEventListener(
-    "message",
-    buildMessageHandler({close, send, onReady, onResponse, onMessage})
-  )
+  const handler = buildMessageHandler({
+    close,
+    send,
+    onReady,
+    onResponse,
+    onMessage,
+  })
+  window.addEventListener("message", handler)
+
   const [$tab, unmount] = renderTab(serviceEndpoint(service))
-  const timer = setInterval(function () {
+  const timer = setInterval(function() {
     if ($tab && $tab.closed) {
       close()
     }
@@ -27,7 +32,7 @@ export function tab(service, opts = {}) {
 
   function close() {
     try {
-      window.removeEventListener("message", buildMessageHandler)
+      window.removeEventListener("message", handler)
       clearInterval(timer)
       unmount()
       onClose()

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/tab.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/tab.js
@@ -22,7 +22,7 @@ export function tab(service, opts = {}) {
   window.addEventListener("message", handler)
 
   const [$tab, unmount] = renderTab(serviceEndpoint(service))
-  const timer = setInterval(function() {
+  const timer = setInterval(function () {
     if ($tab && $tab.closed) {
       close()
     }


### PR DESCRIPTION
### Update event listeners in strategies

Fixes a bug where event listener was not being removed on close
- Updates to listeners in iframe, pop, tab, ext to return reference to handler function and use in removeEventHandler on close