### PR TITLE
change default compute limit to 9999, so tx wont fail cuz of insuffic…

### DIFF
--- a/packages/sdk/src/build/build-transaction.js
+++ b/packages/sdk/src/build/build-transaction.js
@@ -1,7 +1,7 @@
 import {pipe, put, Ok, makeTransaction} from "../interaction/interaction.js"
 import {template} from "@onflow/util-template"
 
-const DEFAULT_COMPUTE_LIMIT = 10
+const DEFAULT_COMPUTE_LIMIT = 9999
 const DEFAULT_SCRIPT_ACCOUNTS = []
 const DEFUALT_REF = null
 


### PR DESCRIPTION
Making fcl use a default compute limit of max will allow tx to go through. Fees are cheap, it's more important to not inconvenience the user and support tx going through.

Change the default tx compute limit to 9999.