### PR TITLE
Address the SSL issue with `flow-app` quickstart

### DIFF
--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -125,7 +125,7 @@ Now run the app using the following command in your terminal.
 npm run start
 ```
 
-You should now see your app running, note that it's running on https ((https://localhost:3000)[https://localhost:3000]).
+You should now see your app running, note that it's running on https ([https://localhost:3000]).
 
 Open this in your preferred browser &amp; you will likely see a warning/error asking you if you want to continue. This is merely because a valid Certificate Authority has not generated our localhost cert (we did), so we can happily dismiss this warning permanently. To all intents and purposes our local comms are secured now, and will work correctly with the CORS `access-control-allow-origin` headers the rest API specifies.
 

--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -125,7 +125,7 @@ Now run the app using the following command in your terminal.
 npm run start
 ```
 
-You should now see your app running, note that it's running on https ([https://localhost:3000]).
+You should now see your app running, note that it's running on [localhost:3000](https://localhost:3000).
 
 Open this in your preferred browser &amp; you will likely see a warning/error asking you if you want to continue. This is merely because a valid Certificate Authority has not generated our localhost cert (we did), so we can happily dismiss this warning permanently. To all intents and purposes our local comms are secured now, and will work correctly with the CORS `access-control-allow-origin` headers the rest API specifies.
 

--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -36,6 +36,81 @@ The first step is to generate a React app using Next.js and [create-next-app](ht
 ```sh
 npx create-next-app@latest flow-app
 cd flow-app
+mkdir -p ssl/certs # we create these directories for ssl configuration
+touch ssl/server.js  # we will populate this file in a moment to enable (self-signed) HTTPS serving on localhost to comply with the API's [useful] CORS security requirements
+```
+
+Then, in your favourite editor, open `ssl/server.js` from your `flow-app` project. Paste &amp; save this:
+
+
+```js
+const { createServer } = require('https');
+const fs = require('fs');
+const { parse } = require('url');
+const next = require('next');
+
+const dev = process.env.NODE_ENV !== 'production';
+const port = process.env.PORT || 3000;
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+    key: fs.readFileSync('ssl/certs/localhost.key'),
+    cert: fs.readFileSync('ssl/certs/localhost.crt')
+};
+
+
+app.prepare().then(() => {
+    createServer(httpsOptions, (req, res) => {
+
+        const parsedUrl = parse(req.url, true)
+        const { pathname, query } = parsedUrl
+
+        // note this is placeholder but could be used to handle custom routing if necessary
+        if (pathname === '/a') {
+            app.render(req, res, '/a', query)
+        } else if (pathname === '/b') {
+            app.render(req, res, '/b', query)
+        } else {
+            handle(req, res, parsedUrl)
+        }
+    }).listen(port, (err) => {
+        if (err) throw err
+        console.log(`> Ready on https://localhost:${port}`)
+    })
+})
+```
+
+Then, replace the `npm run start` start command in `package.json`...
+
+Original:
+
+```json
+    "start": "next start",
+```
+New:
+
+```json
+    "start": "node ssl/server.js",
+```
+
+Finally, we generate our self-signed certificates inside `flow-app`.
+
+To do so, please ensure you have `openssl` installed by executing:
+
+```sh
+openssl --version
+```
+
+If a value is returned, great. If not, please find installation instructions for your OS/distro and come back when it's installed.
+
+The command to generate certs is:
+
+```sh
+openssl req -x509 -out ssl/certs/localhost.crt -keyout ssl/certs/localhost.key \
+  -newkey rsa:2048 -nodes -sha256 \
+  -subj '/CN=localhost' -extensions EXT -config <( \
+printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 ```
 
 Next, install FCL so we can use it in our app.
@@ -47,10 +122,12 @@ npm install @onflow/fcl --save
 Now run the app using the following command in your terminal.
 
 ```sh
-npm run dev
+npm run start
 ```
 
-You should now see your app running.
+You should now see your app running, note that it's running on https ([https://localhost:3000](`https://localhost:3000`)).
+
+Open this in your preferred browser &amp; you will likely see a warning/error asking you if you want to continue. This is merely because a valid Certificate Authority has not generated our localhost cert (we did), so we can happily dismiss this warning permanently. To all intents and purposes our local comms are secured now, and will work correctly with the CORS `access-control-allow-origin` headers the rest API specifies.
 
 ## Configuration
 

--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -125,7 +125,7 @@ Now run the app using the following command in your terminal.
 npm run start
 ```
 
-You should now see your app running, note that it's running on https ([https://localhost:3000](`https://localhost:3000`)).
+You should now see your app running, note that it's running on https ((https://localhost:3000)[https://localhost:3000]).
 
 Open this in your preferred browser &amp; you will likely see a warning/error asking you if you want to continue. This is merely because a valid Certificate Authority has not generated our localhost cert (we did), so we can happily dismiss this warning permanently. To all intents and purposes our local comms are secured now, and will work correctly with the CORS `access-control-allow-origin` headers the rest API specifies.
 


### PR DESCRIPTION
Hey guys,

Great project!

Recently learned about Flow and decided to run through the quickstart guide [quickstart guide](https://docs.onflow.org/fcl/tutorials/flow-app-quickstart).

I was very pleased because everything was smooth up until around [Querying the blockchain](https://docs.onflow.org/fcl/tutorials/flow-app-quickstart/#querying-the-blockchain). Anyways, after a little debugging I noticed that the rest API (for testnet at least) is now requiring the `https` protocol under the `access-control-allow-origin` header for all subsequent requests made to this endpoint. This prevented:

- Init Account
- Execute Transaction

Since I happen to know a fair amount about SSL I configured my own self-signed certs and modified the `flow-app` instance I had along with the `npm start` commands in order to serve my app on `https://localhost:3000`. This PR is the shortest path I saw to offering my contribution to fix this so that new people finding Flow should hopefully breeze all the way through to fully executing.

## What I've done

Updated the Quick Start tutorial (`flow-app`) to generate self-signed SSL certs using the `openssl` cli tool and host them with a simple `server.js` script which is pointed to via package.json `npm run start` command.

## Additional info

I didn't mention "Send Query" above, but that function also had issues for me during quickstart which this PR doesn't expand to fixing. There was an error logged by the Cadence code as copied from the guide for me when trying to execute that function, even when I had succeeded in running the other two main ones.

## Background

I brought this up in the relevant channel on Discord and was asked to submit a PR by @turbolent.