### PR TITLE
[Types] Extend decimal places for UFix64 and Fix64

### DIFF
--- a/packages/types/src/types.js
+++ b/packages/types/src/types.js
@@ -451,6 +451,10 @@ export const UFix64 = type(
         )
       }
 
+      // make sure the number is extended to 8 decimal places so it matches cadence encoding of UFix values
+      vParts[1] = vParts[1].padEnd(8, '0')
+      v = vParts.join(".")
+
       return {
         type: "UFix64",
         value: v,
@@ -482,6 +486,10 @@ export const Fix64 = type(
           `Expected at least one digit, and at most 8 digits following the decimal of the [U]Fix64 value but found ${vParts[1].length} digits. Find out more about [U]Fix64 types here: https://docs.onflow.org/cadence/json-cadence-spec/#fixed-point-numbers`
         )
       }
+
+      // make sure the number is extended to 8 decimal places so it matches cadence encoding of UFix values
+      vParts[1] = vParts[1].padEnd(8, '0')
+      v = vParts.join(".")
 
       return {
         type: "Fix64",

--- a/packages/types/src/types.js
+++ b/packages/types/src/types.js
@@ -487,7 +487,7 @@ export const Fix64 = type(
         )
       }
 
-      // make sure the number is extended to 8 decimal places so it matches cadence encoding of UFix values
+      // make sure the number is extended to 8 decimal places so it matches cadence encoding of Fix64 values
       vParts[1] = vParts[1].padEnd(8, '0')
       v = vParts.join(".")
 

--- a/packages/types/src/types.test.js
+++ b/packages/types/src/types.test.js
@@ -37,8 +37,8 @@ import * as t from "./types.js"
     "64.000000001",
     true,
   ],
-  [t.UFix64, "64.0", {type: "UFix64", value: "64.0"}, "64.0", false],
-  [t.Fix64, "64.0", {type: "Fix64", value: "64.0"}, "64.0", false],
+  [t.UFix64, "64.0", {type: "UFix64", value: "64.00000000"}, "64.0", false],
+  [t.Fix64, "64.0", {type: "Fix64", value: "64.00000000"}, "64.0", false],
   [
     t.String,
     "Go with the Flow",


### PR DESCRIPTION
This PR makes sure the UFix64 and Fix64 are always extended to include 8 decimal places, that is done in order to ensure output that is unified with how Cadence Go implementation formats the Fix numbers. 

This also closes the issue: https://github.com/onflow/cadence/issues/1652