### PR TITLE
[fcl] Updates keyIndices args passed in as Numbers

### DIFF
--- a/.changeset/hungry-otters-relate.md
+++ b/.changeset/hungry-otters-relate.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Updates keyIndices args passed in as Numbers in fcl.verify functions

--- a/packages/fcl/src/app-utils/verify-signatures.js
+++ b/packages/fcl/src/app-utils/verify-signatures.js
@@ -139,7 +139,7 @@ export async function verifyAccountProof(
 
   for (const el of signatures) {
     signaturesArr.push(el.signature)
-    keyIndices.push(el.keyId)
+    keyIndices.push(el.keyId.toString())
   }
 
   return query({
@@ -182,7 +182,7 @@ export async function verifyUserSignatures(message, compSigs, opts = {}) {
 
   for (const el of compSigs) {
     signaturesArr.push(el.signature)
-    keyIndices.push(el.keyId)
+    keyIndices.push(el.keyId.toString())
   }
 
   return query({


### PR DESCRIPTION
### Updates verify queries 
- Indices passed in as Numbers changed to Strings
- Passing in Number as value for Int is deprecated