### PR TITLE
[fcl-js] Ensures 0x prefix on addresses when verifying Composite Signatures 

### DIFF
--- a/.changeset/curly-brooms-marry.md
+++ b/.changeset/curly-brooms-marry.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Adds withPrefix to addresses in verifyAccountProof and verifyUserSignature

--- a/packages/fcl/src/app-utils/__tests__/verify-user-sig.test.js
+++ b/packages/fcl/src/app-utils/__tests__/verify-user-sig.test.js
@@ -29,7 +29,8 @@ const compSigThree = {
 describe("verifyUserSignatures", () => {
   it("should return true if valid args", async () => {
     const compSigs = [compSigOne, compSigTwo]
-    const res = await validateArgs({message, compSigs})
+    const address = "0x6a32b81933f0ee64"
+    const res = await validateArgs({message, address, compSigs})
     expect.assertions(1)
     expect(res).toEqual(true)
   })


### PR DESCRIPTION
### Adds `withPrefix` to addresses in `verifyAccountProof` and `verifyUserSignature`

If the `CompositeSignature` being verified does not use `0x` prefix, the script will fail.
This ensures `0x` prefix on addresses for verification.