### PR TITLE
Make api.md compatible with new docs site

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -861,7 +861,7 @@ See [proving-authentication](https://github.com/onflow/fcl-js/blob/master/docs/r
 | Name                  | Type                  | Description                       |
 | --------------------- | --------------------- | --------------------------------- |
 | `appIdentifier`       | string **(required)** | A hexadecimal string              |
-| `accountProofData`    | Object **(required)** | Object with properties: <br/>`address` {string} - A Flow account address. <br/> `nonce`: `string` - A random string in hexadecimal format (minimum 32 bytes in total, i.e 64 hex characters) <br/> `signatures`: `Object[]` - An array of composite signatures to verify                                                                              |
+| `accountProofData`    | Object **(required)** | Object with properties: <br/>`address`: `string` - A Flow account address. <br/> `nonce`: `string` - A random string in hexadecimal format (minimum 32 bytes in total, i.e 64 hex characters) <br/> `signatures`: `Object[]` - An array of composite signatures to verify                                                                              |
 | `opts`                | Object **(optional)** | `opts.fclCryptoContract` can be provided to overide FCLCryptoContract address for local development                 |
 
 #### Returns


### PR DESCRIPTION
The new site interprets everything as MDX so the `{string}` causes a compile error. I changed this to match the other items in the list which don't use brackets and are valid MDX.