### PR TITLE
PKG -- [transport-http] Retry 429 responses

### DIFF
--- a/.changeset/eleven-bobcats-complain.md
+++ b/.changeset/eleven-bobcats-complain.md
@@ -1,0 +1,5 @@
+---
+"@onflow/transport-http": minor
+---
+
+Retry 429 (Too many requests) responses which are used for access node rate limiting

--- a/.changeset/empty-donkeys-trade.md
+++ b/.changeset/empty-donkeys-trade.md
@@ -1,0 +1,5 @@
+---
+"@onflow/transport-http": patch
+---
+
+Catch JSON error when response body is empty

--- a/package-lock.json
+++ b/package-lock.json
@@ -19315,14 +19315,14 @@
     },
     "packages/fcl": {
       "name": "@onflow/fcl",
-      "version": "1.1.1",
+      "version": "1.2.1-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@onflow/config": "^1.0.3",
         "@onflow/interaction": "0.0.11",
         "@onflow/rlp": "^1.0.2",
-        "@onflow/sdk": "^1.1.1",
+        "@onflow/sdk": "^1.1.2-alpha.0",
         "@onflow/types": "^1.0.3",
         "@onflow/util-actor": "^1.1.1",
         "@onflow/util-address": "^1.0.2",
@@ -19339,7 +19339,7 @@
     },
     "packages/fcl-bundle": {
       "name": "@onflow/fcl-bundle",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.2",
@@ -21661,13 +21661,13 @@
     },
     "packages/sdk": {
       "name": "@onflow/sdk",
-      "version": "1.1.1",
+      "version": "1.1.2-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@onflow/config": "^1.0.3",
         "@onflow/rlp": "^1.0.2",
-        "@onflow/transport-http": "^1.4.0",
+        "@onflow/transport-http": "^1.4.1-alpha.0",
         "@onflow/util-actor": "^1.1.1",
         "@onflow/util-address": "^1.0.2",
         "@onflow/util-invariant": "^1.0.2",
@@ -23840,7 +23840,7 @@
     },
     "packages/transport-http": {
       "name": "@onflow/transport-http",
-      "version": "1.4.0",
+      "version": "1.4.1-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -33818,7 +33818,7 @@
         "@onflow/fcl-bundle": "^1.0.1",
         "@onflow/interaction": "0.0.11",
         "@onflow/rlp": "^1.0.2",
-        "@onflow/sdk": "^1.1.1",
+        "@onflow/sdk": "^1.1.2-alpha.0",
         "@onflow/types": "^1.0.3",
         "@onflow/util-actor": "^1.1.1",
         "@onflow/util-address": "^1.0.2",
@@ -35518,7 +35518,7 @@
         "@onflow/config": "^1.0.3",
         "@onflow/fcl-bundle": "^1.0.1",
         "@onflow/rlp": "^1.0.2",
-        "@onflow/transport-http": "^1.4.0",
+        "@onflow/transport-http": "^1.4.1-alpha.0",
         "@onflow/util-actor": "^1.1.1",
         "@onflow/util-address": "^1.0.2",
         "@onflow/util-invariant": "^1.0.2",

--- a/packages/transport-http/src/http-request.test.js
+++ b/packages/transport-http/src/http-request.test.js
@@ -1,6 +1,39 @@
 import * as fetchTransport from "node-fetch"
 import * as logger from "@onflow/util-logger"
 import {httpRequest} from "./http-request"
+import {Readable} from "stream"
+
+const mockHttpResponse = ({
+  status = 200,
+  body: bodyText = "",
+  statusText = null,
+  ...args
+}) => {
+  const body = new Readable()
+  body.push(bodyText)
+  body.push(null)
+
+  const readStreamToString = readableStream => {
+    let res = "",
+      current
+    while ((current = readableStream.read())) res += current
+    return res
+  }
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body,
+    async json() {
+      return JSON.parse(readStreamToString(this.body))
+    },
+    async text() {
+      return readStreamToString(this.body)
+    },
+    statusText,
+    ...args,
+  }
+}
 
 describe("httpRequest", () => {
   test("makes valid fetch request", async () => {
@@ -35,19 +68,42 @@ describe("httpRequest", () => {
     })
   })
 
+  test("returns result of valid http response", async () => {
+    const spy = jest.spyOn(fetchTransport, "default")
+    const responseBody = {
+      foo: "bar",
+    }
+    spy.mockImplementation(async () =>
+      mockHttpResponse({
+        status: 200,
+        body: JSON.stringify(responseBody),
+      })
+    )
+
+    const opts = {
+      hostname: "https://example.com",
+      path: "/foo/bar",
+      body: "abc123",
+      method: "POST",
+      headers: {
+        Authorization: "Bearer 1RyXjsFJfU",
+      },
+    }
+
+    const result = await httpRequest(opts)
+
+    await expect(result).toEqual(responseBody)
+  })
+
   test("handles http error properly, throws HTTP error", async () => {
     const spy = jest.spyOn(fetchTransport, "default")
-    spy.mockImplementation(async () => ({
-      ok: false,
-      body: JSON.stringify({
-        foo: "bar",
-      }),
-      async json() {
-        return JSON.parse(this.body)
-      },
-      status: 400,
-      statusText: "foo bar",
-    }))
+    spy.mockImplementation(async () =>
+      mockHttpResponse({
+        status: 400,
+        body: JSON.stringify({foo: "bar"}),
+        statusText: "foo bar",
+      })
+    )
 
     const opts = {
       hostname: "https://example.com",
@@ -65,32 +121,19 @@ describe("httpRequest", () => {
   test("retries retriable error", async () => {
     const spy = jest.spyOn(fetchTransport, "default")
 
-    const mockBadResponse = {
-      ok: false,
+    const mockBadResponse = mockHttpResponse({
       body: "",
-      async json() {
-        return JSON.parse(this.body)
-      },
-      async text() {
-        return this.body
-      },
       status: 429, // 429 is a retriable error
       statusText: "Too many requests",
-    }
+    })
 
-    const mockGoodResponse = {
-      ok: true,
-      body: JSON.stringify({
-        foo: "bar",
-      }),
-      async json() {
-        return JSON.parse(this.body)
-      },
-      async text() {
-        return this.body
-      },
-      status: 200,
+    const goodBody = {
+      foo: "bar",
     }
+    const mockGoodResponse = mockHttpResponse({
+      body: JSON.stringify(goodBody),
+      status: 200,
+    })
 
     spy.mockImplementation(async () => {
       if (spy.mock.calls.length === 1) return mockBadResponse
@@ -106,24 +149,22 @@ describe("httpRequest", () => {
 
     const response = await httpRequest(opts)
 
-    await expect(response).toEqual(JSON.parse(mockGoodResponse.body))
+    await expect(response).toEqual(goodBody)
   })
 
   test("handles fetch error properly, displays AN error", async () => {
     const fetchSpy = jest.spyOn(fetchTransport, "default")
 
     fetchSpy.mockImplementation(() =>
-      Promise.reject({
-        ok: false,
-        body: JSON.stringify({
-          foo: "bar",
-        }),
-        async json() {
-          return JSON.parse(this.body)
-        },
-        status: 400,
-        statusText: "foo bar",
-      })
+      Promise.reject(
+        mockHttpResponse({
+          body: JSON.stringify({
+            foo: "bar",
+          }),
+          status: 400,
+          statusText: "foo bar",
+        })
+      )
     )
 
     const loggerSpy = jest.spyOn(logger, "log")


### PR DESCRIPTION
Closes #1363
 - Retry 429 responses
 - Refactor http-request.js for readability
 - Handle empty response body without throwing JSON error