### PR TITLE
PKG -- [fcl] fix arguments' types that are queried along with the signature verification script

### DIFF
--- a/packages/fcl/src/app-utils/verify-signatures.js
+++ b/packages/fcl/src/app-utils/verify-signatures.js
@@ -150,8 +150,8 @@ export async function verifyAccountProof(
     args: (arg, t) => [
       arg(withPrefix(address), t.Address),
       arg(message, t.String),
-      arg(keyIndices, t.Array([t.Int])),
-      arg(signaturesArr, t.Array([t.String])),
+      arg(keyIndices, t.Array(t.Int)),
+      arg(signaturesArr, t.Array(t.String)),
     ],
   })
 }
@@ -193,8 +193,8 @@ export async function verifyUserSignatures(message, compSigs, opts = {}) {
     args: (arg, t) => [
       arg(address, t.Address),
       arg(message, t.String),
-      arg(keyIndices, t.Array([t.Int])),
-      arg(signaturesArr, t.Array([t.String])),
+      arg(keyIndices, t.Array(t.Int)),
+      arg(signaturesArr, t.Array(t.String)),
     ],
   })
 }


### PR DESCRIPTION
With the expression, `t.Array([t.Int])`, the request queries with an array that only carries the first value of the array that is passed as the argument. This will cause the verification to fail when it needs to verify with multiple signatures.

This fix makes sure the script receives the complete array.