### PR TITLE
PKG -- [fcl] Get custom window size in popup src

### DIFF
--- a/.changeset/stale-maps-crash.md
+++ b/.changeset/stale-maps-crash.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": minor
+---
+
+Get custom window size in popup src

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/render-pop.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/render-pop.js
@@ -18,7 +18,10 @@ function popupWindow(url, windowName, win, w, h) {
 
 export function renderPop(src) {
   if (popup == null || popup?.closed) {
-    popup = popupWindow(src, POP, window, 640, 770)
+    const urlParams = new URLSearchParams(window.location.search);
+    const width = urlParams.get('width') || 640
+    const height = urlParams.get('height') || 770
+    popup = popupWindow(src, POP, window, width, height)
   } else if (previousUrl !== src) {
     popup.location.replace(src)
     popup.focus()


### PR DESCRIPTION
This change allows developers to change the size of the popup window by using the query string `width` and `height` in the challenge handshake URL. For example, you can set url query string like `http://localhost/flow/auth?width=500&height=700` to adjust popup window size.

I think this will make wallet provider has more design flexibility. 