### PR TITLE
[fcl][fcl-wc] - Updates to WC adapter API and Discovery Integration

### DIFF
--- a/.changeset/afraid-cobras-wash.md
+++ b/.changeset/afraid-cobras-wash.md
@@ -1,0 +1,15 @@
+---
+"@onflow/fcl": patch
+"@onflow/fcl-wc": patch
+---
+
+### fcl
+
+- Added sending `supportedStrategies` to Discovery (UI/API) on client.config
+
+---
+
+### fcl-wc
+
+- updated `initFclWC` export/name to `init`
+- Added `sessionRequestHook` and `injectedWallets` opts, updated pairing match to use service.uid.

--- a/.changeset/great-avocados-knock.md
+++ b/.changeset/great-avocados-knock.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl-wc": patch
+---
+
+Updates ServicePlugin spec to include serviceStrategy

--- a/.changeset/two-dolphins-tan.md
+++ b/.changeset/two-dolphins-tan.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Updates Service Plugin validation to match spec, adds required serviceStrategy: {method: string, exec: () => {})

--- a/packages/fcl-wc/README.md
+++ b/packages/fcl-wc/README.md
@@ -16,7 +16,7 @@ npm install --save @onflow/fcl-wc
 
 ## Usage
 
-The package exports `initFclWc` and utils.
+The package exports `init` and utils.
 Currently, a WalletConnect `projectId` is required and can be obtained @ https://cloud.walletconnect.com. Metadata is optional.
 
 Initializtion returns `FclWcServicePlugin` and a Walletconnect `client`. The `client` can be used to subscribe to events, disconnect from a wallet, and query session and pairing status.
@@ -24,9 +24,9 @@ Passing `FclWcServicePlugin` to `fcl.pluginRegistry.add()` will enable use of th
 
 ```javascript
 import * as fcl from '@onflow/fcl'
-import { initFclWc } from '@onflow/fcl-wc'
+import { init } from '@onflow/fcl-wc'
 
-const { FclWcServicePlugin, client } = await initFclWc({
+const { FclWcServicePlugin, client } = await init({
   projectId: PROJECT_ID,
   metadata: {
     name: 'FCL WC DApp',

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -4,7 +4,7 @@ import {invariant} from "@onflow/util-invariant"
 import {log} from "@onflow/util-logger"
 import * as fcl from "@onflow/fcl"
 export {getSdkError} from "@walletconnect/utils"
-import {config} from "@onflow/config"
+import {setConfiguredNetwork} from "./utils"
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com"
 const DEFAULT_LOGGER = "debug"
@@ -31,11 +31,6 @@ const initClient = async ({projectId, metadata}) => {
   }
 }
 
-const updateFcl = async projectId => {
-  await config().put("fcl.wc.projectId", projectId)
-  fcl.discovery.authn.update()
-}
-
 export const init = async ({
   projectId,
   metadata,
@@ -44,12 +39,14 @@ export const init = async ({
   wallets = [],
 } = {}) => {
   const client = await initClient({projectId, metadata})
+  await setConfiguredNetwork()
   const FclWcServicePlugin = await makeServicePlugin(client, {
     includeBaseWC,
     sessionRequestHook,
     wallets,
   })
-  await updateFcl(projectId)
+  fcl.discovery.authn.update()
+
   return {
     FclWcServicePlugin,
     client,

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -4,13 +4,14 @@ import {invariant} from "@onflow/util-invariant"
 import {log} from "@onflow/util-logger"
 import * as fcl from "@onflow/fcl"
 export {getSdkError} from "@walletconnect/utils"
+import {config} from "@onflow/config"
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com"
 const DEFAULT_LOGGER = "debug"
 const DEFAULT_APP_METADATA = {
   name: "FCL WalletConnect",
-  description: "FCL DApp for WalletConnect",
-  url: "https://flow.com/",
+  description: "FCL App with WalletConnect",
+  url: "https://flow.com",
   icons: ["https://avatars.githubusercontent.com/u/62387156?s=280&v=4"],
 }
 
@@ -36,10 +37,23 @@ const initClient = async ({projectId, metadata}) => {
   }
 }
 
-export const initFclWc = async ({projectId, metadata} = {}) => {
-  const client = await initClient({projectId, metadata})
-  const FclWcServicePlugin = makeServicePlugin(client)
+const updateFcl = async projectId => {
+  await config().put("fcl.wc.projectId", projectId)
   fcl.discovery.authn.update()
+}
+
+export const initFclWc = async ({
+  projectId,
+  metadata,
+  includeBaseWC = false,
+  wallets = [],
+} = {}) => {
+  const client = await initClient({projectId, metadata})
+  await updateFcl()
+  const FclWcServicePlugin = await makeServicePlugin(client, {
+    includeBaseWC,
+    wallets,
+  })
   return {
     FclWcServicePlugin,
     client,

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -1,7 +1,7 @@
 import SignClient from "@walletconnect/sign-client"
 import {makeServicePlugin} from "./service"
 import {invariant} from "@onflow/util-invariant"
-import {log} from "@onflow/util-logger"
+import {LEVELS, log} from "@onflow/util-logger"
 import * as fcl from "@onflow/fcl"
 export {getSdkError} from "@walletconnect/utils"
 import {setConfiguredNetwork} from "./utils"
@@ -25,7 +25,7 @@ const initClient = async ({projectId, metadata}) => {
     log({
       title: `${error.name} fcl-wc Init Client`,
       message: error.message,
-      level: 1,
+      level: LEVELS.error,
     })
     throw error
   }

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -46,14 +46,16 @@ export const init = async ({
   projectId,
   metadata,
   includeBaseWC = false,
+  sessionRequestHook = null,
   wallets = [],
 } = {}) => {
   const client = await initClient({projectId, metadata})
-  await updateFcl()
   const FclWcServicePlugin = await makeServicePlugin(client, {
     includeBaseWC,
+    sessionRequestHook,
     wallets,
   })
+  await updateFcl(projectId)
   return {
     FclWcServicePlugin,
     client,

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -8,12 +8,6 @@ import {config} from "@onflow/config"
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com"
 const DEFAULT_LOGGER = "debug"
-const DEFAULT_APP_METADATA = {
-  name: "FCL WalletConnect",
-  description: "FCL App with WalletConnect",
-  url: "https://flow.com",
-  icons: ["https://avatars.githubusercontent.com/u/62387156?s=280&v=4"],
-}
 
 const initClient = async ({projectId, metadata}) => {
   invariant(
@@ -25,7 +19,7 @@ const initClient = async ({projectId, metadata}) => {
       logger: DEFAULT_LOGGER,
       relayUrl: DEFAULT_RELAY_URL,
       projectId: projectId,
-      metadata: metadata || DEFAULT_APP_METADATA,
+      metadata: metadata,
     })
   } catch (error) {
     log({

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -42,7 +42,7 @@ const updateFcl = async projectId => {
   fcl.discovery.authn.update()
 }
 
-export const initFclWc = async ({
+export const init = async ({
   projectId,
   metadata,
   includeBaseWC = false,

--- a/packages/fcl-wc/src/fcl-wc.test.js
+++ b/packages/fcl-wc/src/fcl-wc.test.js
@@ -3,6 +3,6 @@ import * as fclWC from "./fcl-wc"
 describe("Init Client", () => {
   it("should throw without projectId", async () => {
     expect.assertions(1)
-    await expect(fclWC.initFclWc()).rejects.toThrow(Error)
+    await expect(fclWC.init()).rejects.toThrow(Error)
   })
 })

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -92,7 +92,7 @@ const makeExec = (client, {sessionRequestHook}) => {
         onResponse(result)
       } catch (e) {
         log({
-          title: `${e.name} Error on WalletConnect request`,
+          title: `${e.name} Error on WalletConnect client ${method} request`,
           message: e.message,
           level: 1,
         })

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -9,9 +9,10 @@ export const makeServicePlugin = client => ({
   f_type: "ServicePlugin",
   type: "discovery-service",
   discoveryServices: makeWcServices(client),
+  serviceStrategy: {method: "WC/RPC", exec: makeExec(client)},
 })
 
-const makeServiceStrategy = client => {
+const makeExec = client => {
   return ({service, body, opts}) => {
     return new Promise(async (resolve, reject) => {
       invariant(client, "WalletConnect is not initialized")
@@ -151,49 +152,43 @@ function makeWcServices(client) {
   const pairings = client.pairing.getAll({active: true})
   return [
     {
-      definition: {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "authn",
+      method: "WC/RPC",
+      uid: "wc#authn",
+      endpoint: "flow_authn",
+      optIn: false,
+      provider: {
+        address: "WalletConnect",
+        name: "WalletConnect",
+        uid: null,
+        icon: "https://avatars.githubusercontent.com/u/37784886",
+        description: "WalletConnect Generic Provider",
+        website: "https://walletconnect.com/",
+        color: null,
+        supportEmail: null,
+      },
+    },
+    ...pairings.map(pairing => {
+      return {
         f_type: "Service",
         f_vsn: "1.0.0",
         type: "authn",
         method: "WC/RPC",
-        uid: "wc#authn",
+        uid: pairing.topic,
         endpoint: "flow_authn",
         optIn: false,
         provider: {
-          address: "WalletConnect",
-          name: "WalletConnect",
-          uid: null,
-          icon: "https://avatars.githubusercontent.com/u/37784886",
-          description: "WalletConnect Generic Provider",
-          website: "https://walletconnect.com/",
+          address: null,
+          name: pairing.peerMetadata.name,
+          uid: pairing.topic,
+          icon: pairing.peerMetadata.icons[0],
+          description: pairing.peerMetadata.description,
+          website: pairing.peerMetadata.url,
           color: null,
           supportEmail: null,
         },
-      },
-      strategy: makeServiceStrategy(client),
-    },
-    ...pairings.map(pairing => {
-      return {
-        definition: {
-          f_type: "Service",
-          f_vsn: "1.0.0",
-          type: "authn",
-          method: "WC/RPC",
-          uid: pairing.topic,
-          endpoint: "flow_authn",
-          optIn: false,
-          provider: {
-            address: null,
-            name: pairing.peerMetadata.name,
-            uid: pairing.topic,
-            icon: pairing.peerMetadata.icons[0],
-            description: pairing.peerMetadata.description,
-            website: pairing.peerMetadata.url,
-            color: null,
-            supportEmail: null,
-          },
-        },
-        strategy: makeServiceStrategy(client),
       }
     }),
   ]

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -57,8 +57,8 @@ const makeExec = client => {
         session = client.session.get(client.session.keys.at(lastKeyIndex))
       }
       if (session == null) {
-        const pairing =
-          service.provider.uid === null ? null : {topic: service.provider.uid}
+        const pairings = client.pairing.getAll({active: true})
+        const pairing = pairings?.find(p => p.topic === service.provider.uid)
 
         session = await connectWc(onClose, {
           service,
@@ -121,11 +121,17 @@ async function connectWc(onClose, {service, client, pairing}) {
       requiredNamespaces,
     })
 
+    const appLink = pairing
+      ? pairing?.peerMetadata?.url
+      : service.provider.website
+
     if (uri) {
-      if (isMobile()) {
+      if (isMobile() && appLink) {
+        const appLink = pairing
+          ? pairing?.peerMetadata?.url
+          : service.provider.website
         const queryString = new URLSearchParams({uri: uri}).toString()
-        // need deep link url for mobile
-        let url = "" + queryString
+        let url = appLink + queryString
         window.open(url, "blank").focus()
       } else {
         QRCodeModal.open(uri, () => {
@@ -165,7 +171,7 @@ function makeWcServices(client) {
         uid: null,
         icon: "https://avatars.githubusercontent.com/u/37784886",
         description: "WalletConnect Generic Provider",
-        website: "https://walletconnect.com/",
+        website: null,
         color: null,
         supportEmail: null,
       },

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -128,7 +128,6 @@ async function connectWc(onClose, {service, client, pairing}) {
     if (isMobile()) {
       const queryString = new URLSearchParams({uri: uri}).toString()
       let url = pairing ? appLink : appLink + "?" + queryString
-      console.log("deepLink", url)
       window.open(url, "blank").focus()
     } else {
       if (!pairing) {
@@ -187,7 +186,6 @@ const baseWalletConnectService = includeBaseWC => {
 const makePairedWalletConnectServices = client => {
   const pairings = client.pairing.getAll({active: true})
   return pairings.map(pairing => {
-    console.log("pairing", pairing)
     return {
       f_type: "Service",
       f_vsn: "1.0.0",
@@ -217,21 +215,6 @@ async function makeWcServices(
   const flowWcWalletServices = await fetchFlowWallets()
   const pairedWalletServices = makePairedWalletConnectServices(client)
 
-  console.log(
-    "pairings",
-    client.pairing.values,
-    "client",
-    client,
-    includeBaseWC,
-    "wcBaseService",
-    wcBaseService,
-    "pairedWalletServices",
-    pairedWalletServices,
-    "injectedWallets",
-    injectedWalletsServices,
-    "WCAPI flow wallets",
-    flowWcWalletServices
-  )
   return [
     ...wcBaseService,
     ...flowWcWalletServices,

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -160,51 +160,24 @@ async function connectWc(onClose, {service, client, pairing}) {
 }
 
 const baseWalletConnectService = includeBaseWC => {
-  return includeBaseWC
-    ? {
-        f_type: "Service",
-        f_vsn: "1.0.0",
-        type: "authn",
-        method: "WC/RPC",
-        uid: "wc#authn",
-        endpoint: "flow_authn",
-        optIn: false,
-        provider: {
-          address: "0xWalletConnect",
-          name: "WalletConnect",
-          uid: null,
-          icon: "https://avatars.githubusercontent.com/u/37784886",
-          description: "WalletConnect Generic Provider",
-          website: null,
-          color: null,
-          supportEmail: null,
-        },
-      }
-    : []
-}
-
-const makePairedWalletConnectServices = client => {
-  const pairings = client.pairing.getAll({active: true})
-  return pairings.map(pairing => {
-    return {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "authn",
-      method: "WC/RPC",
-      uid: pairing.topic,
-      endpoint: "flow_authn",
-      optIn: false,
-      provider: {
-        address: null,
-        name: pairing.peerMetadata.name,
-        icon: pairing.peerMetadata.icons[0],
-        description: pairing.peerMetadata.description,
-        website: pairing.peerMetadata.url,
-        color: null,
-        supportEmail: null,
-      },
-    }
-  })
+  return {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "authn",
+    method: "WC/RPC",
+    uid: "wc#authn",
+    endpoint: "flow_authn",
+    optIn: !includeBaseWC,
+    provider: {
+      address: null,
+      name: "WalletConnect",
+      icon: "https://avatars.githubusercontent.com/u/37784886",
+      description: "WalletConnect Base Service",
+      website: null,
+      color: null,
+      supportEmail: null,
+    },
+  }
 }
 
 async function makeWcServices(
@@ -213,12 +186,6 @@ async function makeWcServices(
 ) {
   const wcBaseService = baseWalletConnectService(includeBaseWC)
   const flowWcWalletServices = await fetchFlowWallets()
-  const pairedWalletServices = makePairedWalletConnectServices(client)
 
-  return [
-    ...wcBaseService,
-    ...flowWcWalletServices,
-    ...injectedWalletsServices,
-    ...pairedWalletServices,
-  ]
+  return [wcBaseService, ...flowWcWalletServices, ...injectedWalletsServices]
 }

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -1,6 +1,6 @@
 import QRCodeModal from "@walletconnect/qrcode-modal"
 import {invariant} from "@onflow/util-invariant"
-import {log} from "@onflow/util-logger"
+import {log, LEVELS} from "@onflow/util-logger"
 import {fetchFlowWallets, isMobile, CONFIGURED_NETWORK} from "./utils"
 
 export const makeServicePlugin = async (client, opts = {}) => ({
@@ -41,7 +41,7 @@ const makeExec = (client, {sessionRequestHook}) => {
           log({
             title: `${error.name} "WC/RPC onResponse error"`,
             message: error.message,
-            level: 1,
+            level: LEVELS.error,
           })
           throw error
         }
@@ -93,7 +93,7 @@ const makeExec = (client, {sessionRequestHook}) => {
         log({
           title: `${e.name} Error on WalletConnect client ${method} request`,
           message: e.message,
-          level: 1,
+          level: LEVELS.error,
         })
         reject(`Declined: Externally Halted`)
       }
@@ -132,7 +132,7 @@ async function connectWc(
           ${pairing.peerMetadata.name}
           Pairing exists, Approve Session in your Mobile Wallet
         `,
-        level: 2,
+        level: LEVELS.warn,
       })
       sessionRequestHook && sessionRequestHook(pairing.peerMetadata)
     } else {
@@ -147,7 +147,7 @@ async function connectWc(
     log({
       title: `${e.name} "Error establishing Walletconnect session"`,
       message: e.message,
-      level: 1,
+      level: LEVELS.error,
     })
     throw e
   } finally {

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -1,6 +1,6 @@
 import {log} from "@onflow/util-logger"
 
-const makeFlowWcWalletServices = wallets => {
+const makeFlowServicesFromWallets = wallets => {
   return Object.values(wallets)
     .filter(w => w.app_type === "wallet")
     .map(wallet => {
@@ -17,7 +17,7 @@ const makeFlowWcWalletServices = wallets => {
           name: wallet.name,
           icon: wallet.image_url?.sm,
           description: wallet.description,
-          website: wallet.mobile?.universal,
+          website: wallet.homepage,
           color: wallet.metadata?.colors?.primary,
           supportEmail: null,
         },
@@ -27,16 +27,18 @@ const makeFlowWcWalletServices = wallets => {
 
 export async function fetchFlowWallets() {
   try {
-    const wallets = await fetch(
+    const wcApiWallets = await fetch(
       "https://explorer-api.walletconnect.com/v1/wallets?entries=5&page=1&search=flow"
     ).then(res => res.json())
-    if (wallets.length === 0) return []
-    const flowWcWalletServices = makeFlowWcWalletServices(wallets.listings)
 
-    return flowWcWalletServices
+    if (wcApiWallets?.count > 0) {
+      return makeFlowServicesFromWallets(wcApiWallets.listings)
+    }
+
+    return []
   } catch (error) {
     log({
-      title: `${error.name} Error connecting to WalletConnect API`,
+      title: `${error.name} Error fetching wallets from WalletConnect API`,
       message: error.message,
       level: 1,
     })

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -1,3 +1,48 @@
+import {log} from "@onflow/util-logger"
+
+const makeFlowWcWalletServices = wallets => {
+  return Object.values(wallets)
+    .filter(w => w.app_type === "wallet")
+    .map(wallet => {
+      return {
+        f_type: "Service",
+        f_vsn: "1.0.0",
+        type: "authn",
+        method: "WC/RPC",
+        uid: wallet.id,
+        endpoint: "flow_authn",
+        optIn: false,
+        provider: {
+          address: wallet.id,
+          name: wallet.name,
+          icon: wallet.image_url?.sm,
+          description: wallet.description,
+          website: wallet.mobile?.universal,
+          color: wallet.metadata?.colors?.primary,
+          supportEmail: null,
+        },
+      }
+    })
+}
+
+export async function fetchFlowWallets() {
+  try {
+    const wallets = await fetch(
+      "https://explorer-api.walletconnect.com/v1/wallets?entries=5&page=1&search=flow"
+    ).then(res => res.json())
+    if (wallets.length === 0) return []
+    const flowWcWalletServices = makeFlowWcWalletServices(wallets.listings)
+
+    return flowWcWalletServices
+  } catch (error) {
+    log({
+      title: `${error.name} Error connecting to WalletConnect API`,
+      message: error.message,
+      level: 1,
+    })
+  }
+}
+
 export function isAndroid() {
   return (
     typeof navigator !== "undefined" && /android/i.test(navigator.userAgent)

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -13,7 +13,7 @@ const makeFlowWcWalletServices = wallets => {
         endpoint: "flow_authn",
         optIn: false,
         provider: {
-          address: wallet.id,
+          address: null,
           name: wallet.name,
           icon: wallet.image_url?.sm,
           description: wallet.description,

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -1,4 +1,16 @@
 import {log} from "@onflow/util-logger"
+import {config} from "@onflow/config"
+import {invariant} from "@onflow/util-invariant"
+
+export let CONFIGURED_NETWORK = null
+
+export const setConfiguredNetwork = async () => {
+  CONFIGURED_NETWORK = await config.get("flow.network")
+  invariant(
+    CONFIGURED_NETWORK === "mainnet" || CONFIGURED_NETWORK === "testnet",
+    "FCL Configuration value for 'flow.network' is required (testnet || mainnet)"
+  )
+}
 
 const makeFlowServicesFromWallets = wallets => {
   return Object.values(wallets)

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -9,7 +9,7 @@ const makeFlowWcWalletServices = wallets => {
         f_vsn: "1.0.0",
         type: "authn",
         method: "WC/RPC",
-        uid: wallet.id,
+        uid: wallet.mobile.universal,
         endpoint: "flow_authn",
         optIn: false,
         provider: {

--- a/packages/fcl/src/current-user/exec-service/plugins.js
+++ b/packages/fcl/src/current-user/exec-service/plugins.js
@@ -21,24 +21,26 @@ const supportedServicePlugins = ["discovery-service"]
 
 const validateDiscoveryPlugin = servicePlugin => {
   const {services, serviceStrategy} = servicePlugin
-  invariant(Array.isArray(services), "Array of Discovery Services is required")
+  invariant(
+    Array.isArray(services) && services.length,
+    "Array of Discovery Services is required"
+  )
 
-  if (services.length) {
-    for (const ds of services) {
-      invariant(
-        isRequired(ds.f_type) && ds.f_type === "Service",
-        "Service is required"
-      )
-      invariant(
-        isRequired(ds.type) && ds.type === "authn",
-        `Service must be type authn. Received ${ds.type}`
-      )
-      invariant(
-        ds.method in CORE_STRATEGIES || serviceStrategy.method === ds.method,
-        `Service method ${ds.method} is not supported`
-      )
-    }
+  for (const ds of services) {
+    invariant(
+      isRequired(ds.f_type) && ds.f_type === "Service",
+      "Service is required"
+    )
+    invariant(
+      isRequired(ds.type) && ds.type === "authn",
+      `Service must be type authn. Received ${ds.type}`
+    )
+    invariant(
+      ds.method in CORE_STRATEGIES || serviceStrategy.method === ds.method,
+      `Service method ${ds.method} is not supported`
+    )
   }
+
   invariant(isRequired(serviceStrategy), "Service strategy is required")
   invariant(
     isRequired(serviceStrategy.method) && isString(serviceStrategy.method),

--- a/packages/fcl/src/current-user/exec-service/plugins.js
+++ b/packages/fcl/src/current-user/exec-service/plugins.js
@@ -4,7 +4,7 @@ import {execPopRPC} from "./strategies/pop-rpc"
 import {execTabRPC} from "./strategies/tab-rpc"
 import {execExtRPC} from "./strategies/ext-rpc"
 import {invariant} from "@onflow/util-invariant"
-import {log} from "@onflow/util-logger"
+import {LEVELS, log} from "@onflow/util-logger"
 import {isRequired, isString, isObject, isFunc} from "../../exec/utils/is"
 
 const CORE_STRATEGIES = {
@@ -73,7 +73,7 @@ const ServiceRegistry = () => {
         log({
           title: `Add Service Plugin`,
           message: `Service strategy for ${serviceStrategy.method} already exists`,
-          level: 2,
+          level: LEVELS.warn,
         })
       }
     }

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -12,6 +12,7 @@ import {normalizeCompositeSignature} from "../normalizers/service/composite-sign
 import {configLens} from "../default-config"
 import {VERSION} from "../VERSION"
 import {getDiscoveryService, makeDiscoveryServices} from "../discovery"
+import {serviceRegistry} from "./exec-service/plugins"
 
 export const isFn = d => typeof d === "function"
 
@@ -128,6 +129,7 @@ const makeConfig = async ({discoveryAuthnInclude}) => {
       fclLibrary: "https://github.com/onflow/fcl-js",
       hostname: window?.location?.hostname ?? null,
       clientServices: await makeDiscoveryServices(),
+      supportedStrategies: serviceRegistry.getStrategies(),
     },
   }
 }

--- a/packages/fcl/src/discovery/services.js
+++ b/packages/fcl/src/discovery/services.js
@@ -1,5 +1,6 @@
 import {config} from "@onflow/config"
 import {invariant} from "@onflow/util-invariant"
+import {serviceRegistry} from "../current-user/exec-service/plugins"
 import {VERSION} from "../VERSION"
 import {makeDiscoveryServices} from "./utils"
 
@@ -23,6 +24,7 @@ export async function getServices({types}) {
       fclVersion: VERSION,
       include,
       clientServices: await makeDiscoveryServices(),
+      supportedStrategies: serviceRegistry.getStrategies(),
       userAgent: window?.navigator?.userAgent,
     }),
   }).then(d => d.json())

--- a/packages/fcl/src/discovery/services/authn.js
+++ b/packages/fcl/src/discovery/services/authn.js
@@ -8,7 +8,7 @@ import {
   send,
 } from "@onflow/util-actor"
 import {getServices} from "../services"
-import {log} from "@onflow/util-logger"
+import {LEVELS, log} from "@onflow/util-logger"
 
 export const SERVICE_ACTOR_KEYS = {
   AUTHN: "authn",
@@ -43,7 +43,7 @@ const fetchServicesFromDiscovery = async () => {
     log({
       title: `${error.name} Error fetching Discovery API services.`,
       message: error.message,
-      level: 1,
+      level: LEVELS.error,
     })
   }
 }

--- a/packages/fcl/src/discovery/utils.js
+++ b/packages/fcl/src/discovery/utils.js
@@ -13,9 +13,7 @@ export async function getDiscoveryService(service) {
     "discovery.wallet.method",
     "discovery.wallet.method.default",
   ])
-  const method = service?.method
-    ? service.method
-    : discoveryWalletMethod
+  const method = service?.method ? service.method : discoveryWalletMethod
   const endpoint =
     service?.endpoint ??
     (await config.first(["discovery.wallet", "challenge.handshake"]))


### PR DESCRIPTION
## Updates to WC adapter API, Service plugin, and Discovery Integration

This PR updates the WalletConnect adapter API, and service plugin returned. It improves Discovery (UI/API) integration by sending strategies supported by the client.

### **fcl-wc** `init` now accepts new args to improve developer experience. 
- `includeBaseWC` (default: false): If true, will include a generic WalletConnect service 
- `sessionRequestHook` (default: null): A function to be called on a Desktop session request so the DApp can inform the user to open and approve in the user's mobile wallet. This will be called if a wallet was previously connected and no QR code scanning is required to pair.
- `wallets` (default: [ ]): **testnet only** The DApp can include an array of wallet services of type `authn`. These will be combined with wallets returned from [WalletConnect cloud registry API](https://cloud.walletconnect.com/), deduped by Service uid and sent to Discovery for display in UI and inclusion in API response. 

:exclamation: In order to correctly identify, improve pairing, and include deep link support for mobile, services using the WC/RPC method need to use the same universal link as their `uid` and `url` in Wallet metadata.
:exclamation: Setting `fcl.config.network` to **testnet** or **mainnet** is required to use `fcl-wc`

