### PR TITLE
Discovery API not loading on SSR apps in Safari and Incognito

### DIFF
--- a/.changeset/young-mice-bow.md
+++ b/.changeset/young-mice-bow.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Fixes issue where Discovery API was not loading for server side rendered applications on Safari or Chrome Incognito.

--- a/packages/fcl/src/discovery/services/authn.js
+++ b/packages/fcl/src/discovery/services/authn.js
@@ -55,8 +55,12 @@ const HANDLERS = {
       '"fcl.discovery" is only available in the browser.'
     )
     // If you call this before the window is loaded extensions will not be set yet
-    window.onload = async () => {
+    if (document.readyState === 'complete') {
       fetchServicesFromDiscovery()
+    } else {
+      window.onload = async () => {
+        fetchServicesFromDiscovery()
+      }
     }
   },
   [SERVICE_ACTOR_KEYS.UPDATE_RESULTS]: (ctx, _letter, data) => {


### PR DESCRIPTION
Looks like page loaded before event listeners are added in Safari. Seems to be an issue with server side rendered apps.

Addresses: https://github.com/onflow/fcl-discovery/issues/106