### PR TITLE
[fcl-wc] add pairing modal override and sessionRequestHook

### DIFF
--- a/.changeset/lazy-poets-return.md
+++ b/.changeset/lazy-poets-return.md
@@ -18,18 +18,9 @@ const { FclWcServicePlugin, client } = await init({
     setSessionRequestData(peerMetadata)
     setShowRequestModal(true)
   },
-  pairingModalOverride: {
-    // required
-    open: (uri: string = '', closeCallback: () => void) => {
-      // open modal for WalletConnect uri
-      // closeCallback() if user closes modal
-      openModal(uri, closeCallback)
-    },
-    // required
-    close: () => {
-      // handle close modal, called by fcl-wc after approval or rejection
-      closeModal()
-    }
+  pairingModalOverride: (uri: string = '', rejectPairingRequest: () => void) => {
+    openCustomPairingModal(uri)
+    // call rejectPairingRequest() to manually reject pairing request from client
   }
 })
 

--- a/.changeset/lazy-poets-return.md
+++ b/.changeset/lazy-poets-return.md
@@ -2,22 +2,23 @@
 "@onflow/fcl-wc": patch
 ---
 
-Adds additional options to init for pairing modal override and sessionRequestHook
+Adds additional options to `init` for `pairingModalOverride` and `wcRequestHook`
 
 ```js
+import * as fcl from '@onflow/fcl'
 import { init } from '@onflow/fcl-wc'
-// example using pairing data from sessionRequestHook and providing a custom pairing modal overide
+// example using pairing data from wcRequestHook and providing a custom pairing modal
 const { FclWcServicePlugin, client } = await init({
   projectId: PROJECT_ID,
   metadata: PROJECT_METADATA,
-  includeBaseWC: true,
-  wallets: []  
-  sessionRequestHook: (data: {session, pairing, uri}) => {
+  includeBaseWC: false,
+  wallets: [],  
+  wcRequestHook: (data: WcRequestData) => {
     const peerMetadata = data?.pairing?.peerMetadata
     setSessionRequestData(peerMetadata)
     setShowRequestModal(true)
   },
-  pairingModalOveride: {
+  pairingModalOverride: {
     // required
     open: (uri: string = '', closeCallback: () => void) => {
       // open modal for WalletConnect uri
@@ -31,4 +32,19 @@ const { FclWcServicePlugin, client } = await init({
     }
   }
 })
+
+fcl.pluginRegistry.add(FclWcServicePlugin)
+
+```
+
+```ts
+
+interface WcRequestData {
+  type: string // 'session_request' | 'pairing_request'
+  session: SessionTypes.Struct | undefined // https://www.npmjs.com/package/@walletconnect/types
+  pairing: PairingTypes.Struct | undefined // https://www.npmjs.com/package/@walletconnect/types
+  method: string // "flow_authn" | "flow_authz" | "flow_user_sign"
+  uri: string | undefined
+}
+
 ```

--- a/.changeset/lazy-poets-return.md
+++ b/.changeset/lazy-poets-return.md
@@ -1,0 +1,34 @@
+---
+"@onflow/fcl-wc": patch
+---
+
+Adds additional options to init for pairing modal override and sessionRequestHook
+
+```js
+import { init } from '@onflow/fcl-wc'
+// example using pairing data from sessionRequestHook and providing a custom pairing modal overide
+const { FclWcServicePlugin, client } = await init({
+  projectId: PROJECT_ID,
+  metadata: PROJECT_METADATA,
+  includeBaseWC: true,
+  wallets: []  
+  sessionRequestHook: (data: {session, pairing, uri}) => {
+    const peerMetadata = data?.pairing?.peerMetadata
+    setSessionRequestData(peerMetadata)
+    setShowRequestModal(true)
+  },
+  pairingModalOveride: {
+    // required
+    open: (uri: string = '', closeCallback: () => void) => {
+      // open modal for WalletConnect uri
+      // closeCallback() if user closes modal
+      openModal(uri, closeCallback)
+    },
+    // required
+    close: () => {
+      // handle close modal, called by fcl-wc after approval or rejection
+      closeModal()
+    }
+  }
+})
+```

--- a/packages/fcl-wc/src/constants.js
+++ b/packages/fcl-wc/src/constants.js
@@ -1,0 +1,10 @@
+export const FLOW_METHODS = {
+  FLOW_AUTHN: "flow_authn",
+  FLOW_AUTHZ: "flow_authz",
+  FLOW_USER_SIGN: "flow_user_sign",
+}
+
+export const REQUEST_TYPES = {
+  SESSION: "session_request",
+  PAIRING: "pairing_request",
+}

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -1,13 +1,14 @@
+import * as fcl from "@onflow/fcl"
 import SignClient from "@walletconnect/sign-client"
 import {makeServicePlugin} from "./service"
 import {invariant} from "@onflow/util-invariant"
 import {LEVELS, log} from "@onflow/util-logger"
-import * as fcl from "@onflow/fcl"
 export {getSdkError} from "@walletconnect/utils"
 import {setConfiguredNetwork} from "./utils"
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com"
 const DEFAULT_LOGGER = "debug"
+let client = null
 
 const initClient = async ({projectId, metadata}) => {
   invariant(
@@ -15,12 +16,13 @@ const initClient = async ({projectId, metadata}) => {
     "FCL Wallet Connect Error: WalletConnect projectId is required"
   )
   try {
-    return SignClient.init({
+    client = await SignClient.init({
       logger: DEFAULT_LOGGER,
       relayUrl: DEFAULT_RELAY_URL,
       projectId: projectId,
       metadata: metadata,
     })
+    return client
   } catch (error) {
     log({
       title: `${error.name} fcl-wc Init Client`,
@@ -39,8 +41,8 @@ export const init = async ({
   wallets = [],
 } = {}) => {
   await setConfiguredNetwork()
-  const client = await initClient({projectId, metadata})
-  const FclWcServicePlugin = await makeServicePlugin(client, {
+  const _client = client ?? (await initClient({projectId, metadata}))
+  const FclWcServicePlugin = await makeServicePlugin(_client, {
     projectId,
     includeBaseWC,
     sessionRequestHook,

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -38,6 +38,7 @@ export const init = async ({
   metadata,
   includeBaseWC = false,
   sessionRequestHook = null,
+  pairingModalOveride = null,
   wallets = [],
 } = {}) => {
   await setConfiguredNetwork()
@@ -46,6 +47,7 @@ export const init = async ({
     projectId,
     includeBaseWC,
     sessionRequestHook,
+    pairingModalOveride,
     wallets,
   })
   fcl.discovery.authn.update()

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -38,9 +38,10 @@ export const init = async ({
   sessionRequestHook = null,
   wallets = [],
 } = {}) => {
-  const client = await initClient({projectId, metadata})
   await setConfiguredNetwork()
+  const client = await initClient({projectId, metadata})
   const FclWcServicePlugin = await makeServicePlugin(client, {
+    projectId,
     includeBaseWC,
     sessionRequestHook,
     wallets,

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -37,8 +37,8 @@ export const init = async ({
   projectId,
   metadata,
   includeBaseWC = false,
-  sessionRequestHook = null,
-  pairingModalOveride = null,
+  wcRequestHook = null,
+  pairingModalOverride = null,
   wallets = [],
 } = {}) => {
   await setConfiguredNetwork()
@@ -46,8 +46,8 @@ export const init = async ({
   const FclWcServicePlugin = await makeServicePlugin(_client, {
     projectId,
     includeBaseWC,
-    sessionRequestHook,
-    pairingModalOveride,
+    wcRequestHook,
+    pairingModalOverride,
     wallets,
   })
   fcl.discovery.authn.update()

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -16,13 +16,9 @@ const makeExec = (client, {wcRequestHook, pairingModalOverride}) => {
   return ({service, body, opts}) => {
     return new Promise(async (resolve, reject) => {
       invariant(client, "WalletConnect is not initialized")
-      let session, pairing, windowRef
+      let session, pairing
       const appLink = service.uid
       const method = service.endpoint
-
-      if (isMobile() && method === FLOW_METHODS.FLOW_AUTHN) {
-        windowRef = window.open("", "_blank")
-      }
 
       const pairings = client.pairing.getAll({active: true})
       if (pairings.length > 0) {
@@ -58,7 +54,6 @@ const makeExec = (client, {wcRequestHook, pairingModalOverride}) => {
       if (session == null) {
         session = await connectWc({
           onClose,
-          windowRef,
           appLink,
           client,
           method,
@@ -136,7 +131,6 @@ const makeExec = (client, {wcRequestHook, pairingModalOverride}) => {
 }
 
 async function connectWc({
-  windowRef,
   onClose,
   appLink,
   client,
@@ -176,8 +170,7 @@ async function connectWc({
     if (isMobile()) {
       const queryString = new URLSearchParams({uri: uri}).toString()
       let url = pairing == null ? appLink + "?" + queryString : appLink
-      windowRef.location.href = url
-      windowRef.focus()
+      window.location.href = url
     } else if (!pairing && uri) {
       if (!pairingModalOverride) {
         QRCodeModal.open(uri, () => {
@@ -201,9 +194,6 @@ async function connectWc({
     onClose()
     throw error
   } finally {
-    if (windowRef && !windowRef.closed) {
-      windowRef.close()
-    }
     QRCodeModal.close()
   }
 }

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -89,10 +89,10 @@ const makeExec = (client, {sessionRequestHook}) => {
           },
         })
         onResponse(result)
-      } catch (e) {
+      } catch (error) {
         log({
-          title: `${e.name} Error on WalletConnect client ${method} request`,
-          message: e.message,
+          title: `${error.name} Error on WalletConnect client ${method} request`,
+          message: error.message,
           level: LEVELS.error,
         })
         reject(`Declined: Externally Halted`)
@@ -143,13 +143,13 @@ async function connectWc(
 
     const session = await approval()
     return session
-  } catch (e) {
+  } catch (error) {
     log({
-      title: `${e.name} "Error establishing Walletconnect session"`,
-      message: e.message,
+      title: `${error.name} "Error establishing Walletconnect session"`,
+      message: error.message,
       level: LEVELS.error,
     })
-    throw e
+    throw error
   } finally {
     QRCodeModal.close()
   }
@@ -176,10 +176,9 @@ const baseWalletConnectService = includeBaseWC => {
   }
 }
 
-async function makeWcServices({includeBaseWC, wallets}) {
+async function makeWcServices({projectId, includeBaseWC, wallets}) {
   const wcBaseService = baseWalletConnectService(includeBaseWC)
-  const flowWcWalletServices = await fetchFlowWallets()
-  const injectedWalletsServices =
-    CONFIGURED_NETWORK === "testnet" ? wallets : []
-  return [wcBaseService, ...flowWcWalletServices, ...injectedWalletsServices]
+  const flowWcWalletServices = (await fetchFlowWallets(projectId)) ?? []
+  const injectedWalletServices = CONFIGURED_NETWORK === "testnet" ? wallets : []
+  return [wcBaseService, ...flowWcWalletServices, ...injectedWalletServices]
 }

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -31,6 +31,7 @@ const makeExec = (client, {wcRequestHook, pairingModalOverride}) => {
       }
 
       if (session) {
+        if (isMobile()) window.location.href = appLink
         log({
           title: "WalletConnect Request",
           message: `

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -154,15 +154,15 @@ async function connectWc({
       sessionRequestHook({session, pairing, uri})
     }
 
-    if (!isMobile() && !pairing) {
-      QRCodeModal.open(uri, () => {
-        onClose()
-      })
-    } else if (isMobile()) {
+    if (isMobile()) {
       const queryString = new URLSearchParams({uri: uri}).toString()
       let url = pairing == null ? appLink + "?" + queryString : appLink
       windowRef.location.href = url
       windowRef.focus()
+    } else if (!pairing) {
+      QRCodeModal.open(uri, () => {
+        onClose()
+      })
     }
 
     const session = await approval()

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -134,7 +134,9 @@ async function connectWc(
         `,
         level: LEVELS.warn,
       })
-      sessionRequestHook && sessionRequestHook(pairing.peerMetadata)
+      if (sessionRequestHook && sessionRequestHook instanceof Function) {
+        sessionRequestHook(pairing.peerMetadata)
+      }
     } else {
       const queryString = new URLSearchParams({uri: uri}).toString()
       let url = pairing == null ? appLink + "?" + queryString : appLink

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -184,16 +184,7 @@ async function connectWc({
           onClose()
         })
       } else {
-        pairingModalOverride.open
-          ? pairingModalOverride.open(uri, () => {
-              onClose()
-            })
-          : log({
-              title: "No open method found on pairingModalOverride",
-              message:
-                "pairingModalOverride should have modal open/close handlers",
-              level: LEVELS.warn,
-            })
+        pairingModalOverride(uri, onClose)
       }
     }
 
@@ -201,25 +192,19 @@ async function connectWc({
     return session
   } catch (error) {
     log({
-      title: `${error.name}: Error establishing Walletconnect session`,
+      title: `Error establishing Walletconnect session`,
       message: `${error.message}
       uri: ${_uri}
       `,
       level: LEVELS.error,
     })
+    onClose()
     throw error
   } finally {
     if (windowRef && !windowRef.closed) {
       windowRef.close()
     }
     QRCodeModal.close()
-    pairingModalOverride?.close
-      ? pairingModalOverride.close()
-      : log({
-          title: "No close method found on pairingModalOverride",
-          message: "pairingModalOverride should have a modal close handler",
-          level: LEVELS.warn,
-        })
   }
 }
 

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -1,4 +1,4 @@
-import {log} from "@onflow/util-logger"
+import {log, LEVELS} from "@onflow/util-logger"
 import {config} from "@onflow/config"
 import {invariant} from "@onflow/util-invariant"
 
@@ -21,7 +21,7 @@ const makeFlowServicesFromWallets = wallets => {
         f_vsn: "1.0.0",
         type: "authn",
         method: "WC/RPC",
-        uid: wallet.mobile.universal,
+        uid: wallet.mobile?.universal,
         endpoint: "flow_authn",
         optIn: false,
         provider: {
@@ -37,10 +37,10 @@ const makeFlowServicesFromWallets = wallets => {
     })
 }
 
-export async function fetchFlowWallets() {
+export const fetchFlowWallets = async projectId => {
   try {
     const wcApiWallets = await fetch(
-      "https://explorer-api.walletconnect.com/v1/wallets?entries=5&page=1&search=flow"
+      `https://explorer-api.walletconnect.com/v3/wallets?projectId=${projectId}&chains=flow:${CONFIGURED_NETWORK}&entries=5&page=1`
     ).then(res => res.json())
 
     if (wcApiWallets?.count > 0) {
@@ -52,7 +52,7 @@ export async function fetchFlowWallets() {
     log({
       title: `${error.name} Error fetching wallets from WalletConnect API`,
       message: error.message,
-      level: 1,
+      level: LEVELS.error,
     })
   }
 }


### PR DESCRIPTION
- Improves deeplinking for pairing and requests on mobile and provides `wcRequestHook` for dApp to alert user of signing request
- Adds additional options to init for pairing modal override

```js
import * as fcl from '@onflow/fcl'
import { init } from '@onflow/fcl-wc'
// example using pairing data from wcRequestHook and providing a custom pairing modal
const { FclWcServicePlugin, client } = await init({
  projectId: PROJECT_ID,
  metadata: PROJECT_METADATA,
  includeBaseWC: false,
  wallets: [],  
  wcRequestHook: (data: WcRequestData) => {
    const peerMetadata = data?.pairing?.peerMetadata
    setSessionRequestData(peerMetadata)
    setShowRequestModal(true)
  },
  pairingModalOverride: (uri: string = '', rejectPairingRequest: () => void) => {
    openCustomPairingModal(uri)
    // call rejectPairingRequest() to manually reject pairing request from client
  }
})

fcl.pluginRegistry.add(FclWcServicePlugin)

```
