### PR TITLE
[fcl] Send discovery include as part of authn client config

### DIFF
--- a/.changeset/empty-experts-complain.md
+++ b/.changeset/empty-experts-complain.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Discovery include now sent as part of authn client config

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -120,8 +120,8 @@ async function getAccountProofData() {
 
 const makeConfig = async ({discoveryAuthnInclude}) => {
   return {
-    discoveryAuthnInclude,
     client: {
+      discoveryAuthnInclude,
       clientServices: await makeDiscoveryServices(),
       supportedStrategies: serviceRegistry.getStrategies(),
     },


### PR DESCRIPTION
This patch adds back `discoveryAuthInclude` as part of config.client sent to discovery