### PR TITLE
export rlp decode

### DIFF
--- a/.changeset/seven-ears-glow.md
+++ b/.changeset/seven-ears-glow.md
@@ -1,0 +1,5 @@
+---
+"@onflow/rlp": patch
+---
+
+export decode method

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dev-wallet/db/*.db
 todo.md
 **/debug.log
 *.log
+.vscode/*

--- a/packages/rlp/src/index.js
+++ b/packages/rlp/src/index.js
@@ -54,24 +54,6 @@ function encodeLength(len, offset) {
   }
 }
 
-function decode(input, stream) {
-  if (stream === void 0) {
-    stream = false
-  }
-  if (!input || input.length === 0) {
-    return Buffer.from([])
-  }
-  var inputBuffer = toBuffer(input)
-  var decoded = _decode(inputBuffer)
-  if (stream) {
-    return decoded
-  }
-  if (decoded.remainder.length !== 0) {
-    throw new Error("invalid remainder")
-  }
-  return decoded.data
-}
-
 /**
  * Get the length of the RLP input
  * @param input
@@ -101,7 +83,7 @@ export function getLength(input) {
 }
 
 /** Decode an input with RLP */
-function _decode(input) {
+export function decode(input) {
   var length, llength, data, innerRemainder, d
   var decoded = []
   var firstByte = input[0]
@@ -144,7 +126,7 @@ function _decode(input) {
     length = firstByte - 0xbf
     innerRemainder = input.slice(1, length)
     while (innerRemainder.length) {
-      d = _decode(innerRemainder)
+      d = decode(innerRemainder)
       decoded.push(d.data)
       innerRemainder = d.remainder
     }
@@ -165,7 +147,7 @@ function _decode(input) {
       throw new Error("invalid rlp, List has a invalid length")
     }
     while (innerRemainder.length) {
-      d = _decode(innerRemainder)
+      d = decode(innerRemainder)
       decoded.push(d.data)
       innerRemainder = d.remainder
     }

--- a/packages/rlp/src/index.js
+++ b/packages/rlp/src/index.js
@@ -83,6 +83,21 @@ export function getLength(input) {
 }
 
 /** Decode an input with RLP */
+
+/**
+ * Built on top of rlp library, removing the BN dependency for the flow.
+ * Package : https://github.com/ethereumjs/rlp
+ * RLP License : https://github.com/ethereumjs/rlp/blob/master/LICENSE
+ *
+ * ethereumjs/rlp is licensed under the
+ * Mozilla Public License 2.0
+ * Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses). Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.
+ **/
+
+/**
+ * @param input - input Will be converted to Uint8Array
+ * @returns returns buffer of decoded data
+ **/
 export function decode(input) {
   var length, llength, data, innerRemainder, d
   var decoded = []


### PR DESCRIPTION
@onflow/rlp package has `encode` but no `decode`

Tasks:
1. Remove unused decode method that takes input and stream
2. Rename old _decode and export rlp decode

Was successful in testing using `npm link` with flow port.

Addresses feature request
https://github.com/onflow/fcl-js/issues/1472