### PR TITLE
[fcl-wc] - Adds support for pre-authz method

### DIFF
--- a/.changeset/tiny-lies-cheer.md
+++ b/.changeset/tiny-lies-cheer.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl-wc": minor
+---
+
+Add support for pre-authz method

--- a/packages/fcl-wc/src/constants.js
+++ b/packages/fcl-wc/src/constants.js
@@ -1,5 +1,6 @@
 export const FLOW_METHODS = {
   FLOW_AUTHN: "flow_authn",
+  FLOW_PRE_AUTHZ: "flow_pre_authz",
   FLOW_AUTHZ: "flow_authz",
   FLOW_USER_SIGN: "flow_user_sign",
 }

--- a/packages/fcl-wc/src/fcl-wc.js
+++ b/packages/fcl-wc/src/fcl-wc.js
@@ -34,8 +34,8 @@ const initClient = async ({projectId, metadata}) => {
 }
 
 export const init = async ({
-  projectId,
-  metadata,
+  projectId = null,
+  metadata = {},
   includeBaseWC = false,
   wcRequestHook = null,
   pairingModalOverride = null,

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -293,6 +293,6 @@ const makeBaseWalletConnectService = includeBaseWC => {
 async function makeWcServices({projectId, includeBaseWC, wallets}) {
   const wcBaseService = makeBaseWalletConnectService(includeBaseWC)
   const flowWcWalletServices = (await fetchFlowWallets(projectId)) ?? []
-  const injectedWalletServices = CONFIGURED_NETWORK === "testnet" ? wallets : []
+  const injectedWalletServices = CONFIGURED_NETWORK !== "mainnet" ? wallets : []
   return [wcBaseService, ...flowWcWalletServices, ...injectedWalletServices]
 }

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -200,6 +200,7 @@ async function connectWc({
     flow: {
       methods: [
         FLOW_METHODS.FLOW_AUTHN,
+        FLOW_METHODS.FLOW_PRE_AUTHZ,
         FLOW_METHODS.FLOW_AUTHZ,
         FLOW_METHODS.FLOW_USER_SIGN,
       ],

--- a/packages/fcl-wc/src/utils.js
+++ b/packages/fcl-wc/src/utils.js
@@ -7,8 +7,8 @@ export let CONFIGURED_NETWORK = null
 export const setConfiguredNetwork = async () => {
   CONFIGURED_NETWORK = await config.get("flow.network")
   invariant(
-    CONFIGURED_NETWORK === "mainnet" || CONFIGURED_NETWORK === "testnet",
-    "FCL Configuration value for 'flow.network' is required (testnet || mainnet)"
+    CONFIGURED_NETWORK,
+    "FCL Configuration value for 'flow.network' is required"
   )
 }
 


### PR DESCRIPTION
### Adds support for pre-authz method

- Adds `flow_pre_authz` to requiredNamespaces
- Removes constraint for test/mainnet only allowing for dev of emulator wallets