### PR TITLE
PKG -- [transport-http] Fix getBlockHeader

### DIFF
--- a/packages/transport-http/src/send-get-block-header.js
+++ b/packages/transport-http/src/send-get-block-header.js
@@ -30,7 +30,7 @@ async function sendGetBlockHeaderByHeightRequest(ix, context, opts) {
 async function sendGetLatestBlockHeaderRequest(ix, context, opts) {
   const httpRequest = opts.httpRequest || defaultHttpRequest
 
-  const height = ix.block?.isSealed ? "sealed" : "finalized"
+  const height = ix.block?.isSealed ? "sealed" : "final"
 
   const res = await httpRequest({
     hostname: opts.node,

--- a/packages/transport-http/src/send-get-block-header.test.js
+++ b/packages/transport-http/src/send-get-block-header.test.js
@@ -154,7 +154,7 @@ describe("Send Get Block Header", () => {
 
     expect(valueSent).toEqual({
       hostname: "localhost",
-      path: "/v1/blocks?height=finalized",
+      path: "/v1/blocks?height=final",
       method: "GET",
       body: null,
     })


### PR DESCRIPTION
GetBlockHeader should send "height=final" instead of "height=finalized" based on https://github.com/onflow/flow-go/blob/6a817aabdf58011ffc917bd6b2335160bff7793f/engine/access/rest/request/height.go#L10