### PR TITLE
Ensure zero x prefix

### DIFF
--- a/.changeset/warm-schools-jump.md
+++ b/.changeset/warm-schools-jump.md
@@ -1,0 +1,5 @@
+---
+"@onflow/sdk": patch
+---
+
+Prefix contract addresses with 0x if not preset in the config during Address replacement.

--- a/packages/sdk/src/resolve/resolve-cadence.js
+++ b/packages/sdk/src/resolve/resolve-cadence.js
@@ -2,6 +2,7 @@ import {isTransaction, isScript, get} from "../interaction/interaction.js"
 import {invariant} from "@onflow/util-invariant"
 import {config} from "@onflow/config"
 import * as logger from "@onflow/util-logger"
+import {withPrefix} from "@onflow/util-address"
 
 const isFn = v => typeof v === "function"
 const isString = v => typeof v === "string"
@@ -54,7 +55,7 @@ export async function resolveCadence(ix) {
       if (address) {
         cadence = cadence.replace(
           fullMatch,
-          `import ${contractName} from ${address}`
+          `import ${contractName} from ${withPrefix(address)}`
         )
       } else {
         logger.log({

--- a/packages/sdk/src/resolve/resolve-cadence.test.js
+++ b/packages/sdk/src/resolve/resolve-cadence.test.js
@@ -197,5 +197,30 @@ pub fun main(): Address {
 
       expect(ix.message.cadence).toEqual(expected)
     })
+
+    test("should prefix addresses with `0x` if not already present", async () => {
+      const CADENCE = `import "Foo"
+
+pub fun main(): Address {
+  return "Foo"
+}`
+
+      const expected = `import Foo from 0x1
+
+pub fun main(): Address {
+  return "Foo"
+}`
+
+      await config().put("system.contracts.Foo", "1")
+      await idle()
+
+      const ix = await pipe([
+        makeScript,
+        put("ix.cadence", CADENCE),
+        resolveCadence,
+      ])(interaction())
+
+      expect(ix.message.cadence).toEqual(expected)
+    })
   })
 })


### PR DESCRIPTION
The addresses in flow.json are not guaranteed to be prefixed with a `0x` but they are needed for valid scripts and transactions. 