### PR TITLE
PKG -- [fcl] Retry on network error is page is not visible during backchannel polling

### DIFF
--- a/.changeset/unlucky-pugs-battle.md
+++ b/.changeset/unlucky-pugs-battle.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+PKG -- [fcl] Retry on network error is page is not visible during backchannel polling

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
@@ -36,12 +36,13 @@ export async function poll(service, canContinue = () => true) {
   } catch (error) {
     if (
       typeof document !== "undefined" &&
-      document.visibilityState === "visible"
+      document.visibilityState === "hidden"
     ) {
       await new Promise(r => setTimeout(r, 500))
-      return poll(resp.updates, canContinue)
+      return poll(service, canContinue)
+    } else {
+      throw error
     }
-    throw error
   }
 
   switch (resp.status) {

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
@@ -28,9 +28,21 @@ export async function poll(service, canContinue = () => true) {
   invariant(service, "Missing Polling Service", {service})
   if (!canContinue()) throw new Error("Externally Halted")
 
-  const resp = await fetchService(service, {
-    method: serviceMethod(service),
-  }).then(normalizePollingResponse)
+  let resp
+  try {
+    resp = await fetchService(service, {
+      method: serviceMethod(service),
+    }).then(normalizePollingResponse)
+  } catch (error) {
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "visible"
+    ) {
+      await new Promise(r => setTimeout(r, 500))
+      return poll(resp.updates, canContinue)
+    }
+    throw error
+  }
 
   switch (resp.status) {
     case "APPROVED":


### PR DESCRIPTION
PKG -- [fcl] Retry on network error is page is not visible during backchannel polling

Closes: https://github.com/onflow/fcl-js/issues/1582