### PR TITLE
PKG -- [fcl] Skip network requests when polling on service if document is not visible

### DIFF
--- a/.changeset/selfish-parents-argue.md
+++ b/.changeset/selfish-parents-argue.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+PKG -- [fcl] Skip network requests when polling on service if document is not visible

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/poll.js
@@ -30,19 +30,19 @@ export async function poll(service, canContinue = () => true) {
 
   let resp
   try {
-    resp = await fetchService(service, {
-      method: serviceMethod(service),
-    }).then(normalizePollingResponse)
-  } catch (error) {
     if (
       typeof document !== "undefined" &&
       document.visibilityState === "hidden"
     ) {
       await new Promise(r => setTimeout(r, 500))
       return poll(service, canContinue)
-    } else {
-      throw error
     }
+
+    resp = await fetchService(service, {
+      method: serviceMethod(service),
+    }).then(normalizePollingResponse)
+  } catch (error) {
+    throw error
   }
 
   switch (resp.status) {


### PR DESCRIPTION
PKG -- [fcl] Skip network requests when polling on service if document is not visible

Closes: https://github.com/onflow/fcl-js/issues/1582#issuecomment-1521623365 https://github.com/onflow/fcl-js/issues/1634