### PR TITLE
Fix Jest on node v18.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24202,7 +24202,7 @@
     },
     "packages/fcl": {
       "name": "@onflow/fcl",
-      "version": "1.4.0-alpha.8",
+      "version": "1.4.0-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -24221,7 +24221,7 @@
       },
       "devDependencies": {
         "@onflow/fcl-bundle": "^1.3.0-alpha.0",
-        "@onflow/typedefs": "^1.1.0-alpha.4",
+        "@onflow/typedefs": "^1.1.0-alpha.5",
         "@types/node": "^18.13.0",
         "eslint": "^8.35.0",
         "eslint-plugin-jsdoc": "^40.0.1",
@@ -24261,7 +24261,7 @@
     },
     "packages/fcl-wc": {
       "name": "@onflow/fcl-wc",
-      "version": "2.0.0-alpha.5",
+      "version": "2.0.0-alpha.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.9",
@@ -24280,7 +24280,7 @@
         "jest-esm-transformer": "1.0.0"
       },
       "peerDependencies": {
-        "@onflow/fcl": "^1.4.0-alpha.5"
+        "@onflow/fcl": "^1.4.0-alpha.9"
       }
     },
     "packages/fcl-wc/node_modules/@jest/console": {
@@ -33387,7 +33387,7 @@
     },
     "packages/typedefs": {
       "name": "@onflow/typedefs",
-      "version": "1.1.0-alpha.4",
+      "version": "1.1.0-alpha.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.18.6"
@@ -45029,7 +45029,7 @@
         "@onflow/interaction": "0.0.11",
         "@onflow/rlp": "^1.1.0-alpha.0",
         "@onflow/sdk": "^1.2.0-alpha.7",
-        "@onflow/typedefs": "^1.1.0-alpha.4",
+        "@onflow/typedefs": "^1.1.0-alpha.5",
         "@onflow/types": "^1.1.0-alpha.0",
         "@onflow/util-actor": "^1.2.0-alpha.0",
         "@onflow/util-address": "^1.1.0-alpha.3",

--- a/packages/fcl-wc/package.json
+++ b/packages/fcl-wc/package.json
@@ -18,7 +18,6 @@
     },
     "testEnvironment": "./jest-test-environment.js",
     "globals": {
-      "window": {},
       "PACKAGE_CURRENT_VERSION": "TESTVERSION"
     }
   },

--- a/packages/fcl/package.json
+++ b/packages/fcl/package.json
@@ -18,7 +18,6 @@
     },
     "testEnvironment": "jsdom",
     "globals": {
-      "window": {},
       "PACKAGE_CURRENT_VERSION": "TESTVERSION"
     }
   },


### PR DESCRIPTION
Addresses: https://github.com/onflow/fcl-js/issues/1653
----------
We were running into this issue https://github.com/nodejs/node/issues/47563.  Removing the "window" global appears to be sufficient to fix this.