### PR TITLE
PKG -- [fcl] Patch URL trailing slash behaviour in React Native

### DIFF
--- a/.changeset/tasty-shirts-flow.md
+++ b/.changeset/tasty-shirts-flow.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Patch URL trailing slash bug in React Native

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/service-endpoint.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/service-endpoint.js
@@ -1,3 +1,5 @@
+import {URL} from "../../../../utils/url"
+
 export function serviceEndpoint(service) {
   const url = new URL(service.endpoint)
   if (window?.location?.origin) {

--- a/packages/fcl/src/current-user/fetch-services.js
+++ b/packages/fcl/src/current-user/fetch-services.js
@@ -1,3 +1,5 @@
+import {URL} from "../utils/url"
+
 export async function fetchServices(servicesURL, code) {
   if (servicesURL == null || code == null) return []
 

--- a/packages/fcl/src/current-user/url-from-service.js
+++ b/packages/fcl/src/current-user/url-from-service.js
@@ -1,3 +1,5 @@
+import {URL} from "../utils/url"
+
 export function urlFromService(service, includeParams = true) {
   const url = new URL(service.endpoint)
   if (includeParams) {

--- a/packages/fcl/src/discovery/services.js
+++ b/packages/fcl/src/discovery/services.js
@@ -4,6 +4,7 @@ import {getServiceRegistry} from "../current-user/exec-service/plugins"
 import {getChainId} from "../utils"
 import {VERSION} from "../VERSION"
 import {makeDiscoveryServices} from "./utils"
+import {URL} from "../utils/url"
 
 export async function getServices({types}) {
   const endpoint = await config.get("discovery.authn.endpoint")

--- a/packages/fcl/src/fcl-react-native.js
+++ b/packages/fcl/src/fcl-react-native.js
@@ -3,10 +3,14 @@ export * from './shared-exports';
 import {config} from "@onflow/config"
 import {execLocal, getDefaultConfig, useServiceDiscovery, ServiceDiscovery} from "./utils/react-native"
 import {initServiceRegistry} from "./current-user/exec-service/plugins"
+import {setIsReactNative} from './utils/is-react-native';
 
 config(getDefaultConfig())
 
 // Set chain id default on access node change
 initServiceRegistry({execLocal})
+
+// Set isReactNative flag
+setIsReactNative(true)
 
 export {useServiceDiscovery, ServiceDiscovery}

--- a/packages/fcl/src/utils/is-react-native.js
+++ b/packages/fcl/src/utils/is-react-native.js
@@ -1,0 +1,9 @@
+let _isReactNative = false
+
+export function isReactNative() {
+  return _isReactNative
+}
+
+export function setIsReactNative(value) {
+  _isReactNative = value
+}

--- a/packages/fcl/src/utils/url.js
+++ b/packages/fcl/src/utils/url.js
@@ -9,16 +9,15 @@
 // See react-native implementation: https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Blob/URL.js#L144-L146
 
 // This is not polyfilled globally because it could break other libraries or the user's code
+import {isReactNative} from "./is-react-native"
+
 const _URL = globalThis.URL
 export class URL extends _URL {
   constructor(url, base, ...args) {
     super(url, base, ...args)
 
     // Extra check if in React Native
-    if (
-      typeof navigator === "undefined" ||
-      navigator.product !== "ReactNative"
-    ) {
+    if (!isReactNative()) {
       return
     }
 

--- a/packages/fcl/src/utils/url.js
+++ b/packages/fcl/src/utils/url.js
@@ -1,0 +1,21 @@
+// This is a workaround for an ongoing issue with URL in React Native
+// It does not parse the URL correctly and appends trailing slashes
+// See: https://github.com/facebook/react-native/issues/24428
+// See: https://github.com/facebook/react-native/issues/24428
+
+// The React Native team is aware of this issue but does not plan to fix it
+// since it could break existing apps, even though this is out of spec
+// See whatwg implementation: https://github.com/jsdom/whatwg-url/blob/master/lib/URL-impl.js#L6-L34
+// See react-native implementation: https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Blob/URL.js#L144-L146
+
+// This is not polyfilled globally because it could break other libraries or the user's code
+const _URL = globalThis.URL
+export class URL extends _URL {
+  constructor(url, base, ...args) {
+    super(url, base, ...args)
+
+    if (this._url && !url.endsWith("/") && this._url.endsWith("/")) {
+      this._url = this._url.slice(0, -1)
+    }
+  }
+}

--- a/packages/fcl/src/utils/url.js
+++ b/packages/fcl/src/utils/url.js
@@ -14,6 +14,15 @@ export class URL extends _URL {
   constructor(url, base, ...args) {
     super(url, base, ...args)
 
+    // Extra check if in React Native
+    if (
+      typeof navigator === "undefined" ||
+      navigator.product !== "ReactNative"
+    ) {
+      return
+    }
+
+    // Fix trailing slash issue
     if (this._url && !url.endsWith("/") && this._url.endsWith("/")) {
       this._url = this._url.slice(0, -1)
     }


### PR DESCRIPTION
Closes #1692 

This is a really nasty bug that is affecting the dev wallet currently and potentially other wallets in the future.  See the issue provided for an overview of why these changes are needed.  TLDR: react native violates WhatWG URL standard

I've added a wonky patch to the react-native scaffold for now https://github.com/jribbink/fcl-react-native-scaffold/commit/041d50486c44cc39a1428f15c9cf8a37ef8253b2, but this should be killed ASAP.  Just figured that working with a wonky patch > not working for the interim