### PR TITLE
PKG -- [sdk] Fixed args type for send

### DIFF
--- a/.changeset/warm-dolls-tan.md
+++ b/.changeset/warm-dolls-tan.md
@@ -1,0 +1,5 @@
+---
+"@onflow/sdk": patch
+---
+
+Fixed args type for send

--- a/packages/sdk/src/send/send.js
+++ b/packages/sdk/src/send/send.js
@@ -9,7 +9,7 @@ import {resolve as defaultResolve} from "../resolve/resolve.js"
 
 /**
  * @description - Sends arbitrary scripts, transactions, and requests to Flow
- * @param {Array.<Function>} args - An array of functions that take interaction and return interaction
+ * @param {Array.<Function> | Array<object>} args - An array of functions that take interaction and return interaction
  * @param {object} opts - Optional parameters
  * @returns {Promise<*>} - A promise that resolves to a response
  */


### PR DESCRIPTION
#1717

- fix type definition for `args` in `send`