### PR TITLE
Bump FCL & add changeset for SDK typedef patch

### DIFF
--- a/.changeset/blue-eggs-care.md
+++ b/.changeset/blue-eggs-care.md
@@ -2,4 +2,4 @@
 "@onflow/fcl": patch
 ---
 
-Fixed types for sdk builders functions (fixes sdk.send/sdk.build type errors)
+Fixed types for sdk builders functions (fixes fcl.send/fcl.build type errors)

--- a/.changeset/blue-eggs-care.md
+++ b/.changeset/blue-eggs-care.md
@@ -2,4 +2,4 @@
 "@onflow/fcl": patch
 ---
 
-Fixed types for sdk builders functions (fixes fcl.send/fcl.build type errors)
+Fixed types for sdk builder functions (fixes fcl.send/fcl.build type errors)

--- a/.changeset/blue-eggs-care.md
+++ b/.changeset/blue-eggs-care.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl": patch
+---
+
+Fixed types for sdk builders functions (fixes sdk.send/sdk.build type errors)


### PR DESCRIPTION
We should patch bump FCL as well so that the new SDK changes can be reflected