### PR TITLE
PKG -- [transport-http] Fix responseBody not included in errors

### DIFF
--- a/.changeset/perfect-bananas-deny.md
+++ b/.changeset/perfect-bananas-deny.md
@@ -1,0 +1,7 @@
+---
+"@onflow/transport-http": patch
+"@onflow/fcl": patch
+"@onflow/sdk": patch
+---
+
+Fix responseBody not being included in errors

--- a/packages/transport-http/src/http-request.js
+++ b/packages/transport-http/src/http-request.js
@@ -80,7 +80,7 @@ export async function httpRequest({
           return res.json()
         }
 
-        const responseText = res.body ? await res.text() : null
+        const responseText = await res.text().catch(() => null)
         const response = safeParseJSON(responseText)
 
         throw new HTTPRequestError({


### PR DESCRIPTION
cross-fetch doesn't set res.body.  I don't think `res.text()` will actually run into a scenario where it throws (i.e. non utf-8 response), but I catch error just in case

closes #1762