### PR TITLE
Fix JSDoc type generation

### DIFF
--- a/packages/fcl-bundle/src/build/get-input-options.js
+++ b/packages/fcl-bundle/src/build/get-input-options.js
@@ -73,6 +73,16 @@ module.exports = function getInputOptions(package, build) {
       isTypeScript &&
         typescript({
           clean: true,
+          include: [
+            "*.ts+(|x)",
+            "**/*.ts+(|x)",
+            "**/*.cts",
+            "**/*.mts",
+            "*.js+(|x)",
+            "**/*.js+(|x)",
+            "**/*.cjs",
+            "**/*.mjs",
+          ],
         }),
       replace({
         preventAssignment: true,


### PR DESCRIPTION
Closes #1779 

Surprisingly simple fix.  Apparently `rollup-plugin-typescript2` doesn't ingest .js files by default.