### PR TITLE
fix: @onflow/fcl-wc in vite + TS envirtonment

### DIFF
--- a/packages/fcl-wc/package.json
+++ b/packages/fcl-wc/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/onflow/fcl-js/issues"
   },
+  "type": "module",
   "files": [
     "dist"
   ],

--- a/packages/fcl-wc/package.json
+++ b/packages/fcl-wc/package.json
@@ -17,7 +17,22 @@
     "dist"
   ],
   "source": "src/fcl-wc.js",
-  "module": "dist/fcl-wc.module.js",
+  "main": "dist/fcl-wc.js",
+  "module": "dist/fcl-wc.module.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/fcl-wc.module.mjs",
+      "require": "./dist/fcl-wc.js"
+    },
+    "./dist/fcl-wc.js": {
+      "import": "./dist/fcl-wc.module.mjs",
+      "require": "./dist/fcl-wc.js"
+    },
+    "./dist/fcl-wc.module.mjs": {
+      "import": "./dist/fcl-wc.module.mjs",
+      "require": "./dist/fcl-wc.js"
+    }
+  },
   "scripts": {
     "prepublishOnly": "npm test && npm run build",
     "test": "jest",


### PR DESCRIPTION
 to avoid error
```
SyntaxError: Cannot use import statement outside a module
```
when using `@onflow/fcl-wc` in vite + TS environment