### PR TITLE
Update access modifiers to support Cadence 1.0

### DIFF
--- a/.changeset/poor-kids-care.md
+++ b/.changeset/poor-kids-care.md
@@ -1,0 +1,8 @@
+---
+"@onflow/transport-grpc": patch
+"@onflow/transport-http": patch
+"@onflow/fcl-core": patch
+"@onflow/sdk": patch
+---
+
+Update access modifiers to support Cadence 1.0

--- a/packages/fcl-core/src/app-utils/verify-signatures.js
+++ b/packages/fcl-core/src/app-utils/verify-signatures.js
@@ -80,7 +80,7 @@ const getVerifySignaturesScript = async (sig, opts) => {
   return `
       import FCLCrypto from ${fclCryptoContract}
 
-      pub fun main(
+      access(all) fun main(
           address: Address, 
           message: String, 
           keyIndices: [Int], 

--- a/packages/fcl-core/src/exec/query.js
+++ b/packages/fcl-core/src/exec/query.js
@@ -17,7 +17,7 @@ import {preQuery} from "./utils/pre.js"
  *  @example
  *    const cadence = `
  *      cadence: `
- *        pub fun main(a: Int, b: Int, c: Address): Int {
+ *        access(all) fun main(a: Int, b: Int, c: Address): Int {
  *          log(c)
  *          return a + b
  *        }

--- a/packages/fcl-core/src/interaction-template-utils/get-interaction-template-audits.js
+++ b/packages/fcl-core/src/interaction-template-utils/get-interaction-template-audits.js
@@ -78,7 +78,7 @@ export async function getInteractionTemplateAudits(
       const audits = await query({
         cadence: `
         import FlowInteractionTemplateAudit from ${FlowInteractionAuditContract}
-        pub fun main(templateId: String, auditors: [Address]): {Address:Bool} {
+        access(all) fun main(templateId: String, auditors: [Address]): {Address:Bool} {
           return FlowInteractionTemplateAudit.getHasTemplateBeenAuditedByAuditors(templateId: templateId, auditors: auditors)
         }
         `,

--- a/packages/fcl-core/src/interaction-template-utils/utils/find-imports.test.js
+++ b/packages/fcl-core/src/interaction-template-utils/utils/find-imports.test.js
@@ -6,7 +6,7 @@ describe("Find imports", () => {
         import ContractA from 0xABC123
         import ContractB from 0xDEF456
 
-        pub fun main(): Int {
+        access(all) fun main(): Int {
             return 12
         }
     `
@@ -16,7 +16,7 @@ describe("Find imports", () => {
         import ContractB from 0xDEF456
         import Crypto
 
-        pub fun main(): Int {
+        access(all) fun main(): Int {
             return 12
         }
     `
@@ -28,7 +28,7 @@ describe("Find imports", () => {
     import ContractC from 0xDEF456
     import Crypto
 
-    pub fun main(): Int {
+    access(all) fun main(): Int {
         return 12
     }
 `

--- a/packages/sdk/src/build/build-script.test.js
+++ b/packages/sdk/src/build/build-script.test.js
@@ -3,7 +3,7 @@ import {script} from "./build-script.js"
 
 describe("Build Script", () => {
   test("Build Script", async () => {
-    const cadence = "pub fun main(): Int { return 123 }"
+    const cadence = "access(all) fun main(): Int { return 123 }"
 
     let ix = await script(cadence)(initInteraction())
 

--- a/packages/sdk/src/resolve/resolve-cadence.test.js
+++ b/packages/sdk/src/resolve/resolve-cadence.test.js
@@ -1,4 +1,9 @@
-import {initInteraction, pipe, put, makeScript} from "../interaction/interaction"
+import {
+  initInteraction,
+  pipe,
+  put,
+  makeScript,
+} from "../interaction/interaction"
 import {resolveCadence} from "./resolve-cadence.js"
 import {config} from "@onflow/config"
 
@@ -37,7 +42,7 @@ describe("resolveCadence", () => {
         return `
         import MyContract from 0xMY_CONTRACT_ADDRESS
   
-        pub fun main(): Address {
+        access(all) fun main(): Address {
           return 0xMY_CONTRACT_ADDRESS
         }
       `
@@ -47,7 +52,7 @@ describe("resolveCadence", () => {
         return `
         import MyContract from 0x123abc
   
-        pub fun main(): Address {
+        access(all) fun main(): Address {
           return 0x123abc
         }
       `
@@ -70,18 +75,18 @@ describe("resolveCadence", () => {
         import FooBar from 0xFoo
         import FooBar from 0xFooBar
 
-        pub fun main(): Address {
+        access(all) fun main(): Address {
           log(0xFoo)
           return 0xFoo
         }
 
-        pub fun other(): Address {
+        access(all) fun other(): Address {
           log(0xFooBar)
           return 0xFooBar
         }
 
-        pub fun otherTwo(): Address {return 0xFoo}
-        pub fun otherThree(): Address {return 0xFooBar}
+        access(all) fun otherTwo(): Address {return 0xFoo}
+        access(all) fun otherThree(): Address {return 0xFooBar}
       `
       }
 
@@ -90,18 +95,18 @@ describe("resolveCadence", () => {
         import FooBar from 0x123
         import FooBar from 0x456
 
-        pub fun main(): Address {
+        access(all) fun main(): Address {
           log(0x123)
           return 0x123
         }
 
-        pub fun other(): Address {
+        access(all) fun other(): Address {
           log(0x456)
           return 0x456
         }
 
-        pub fun otherTwo(): Address {return 0x123}
-        pub fun otherThree(): Address {return 0x456}
+        access(all) fun otherTwo(): Address {return 0x123}
+        access(all) fun otherThree(): Address {return 0x456}
       `
       }
 
@@ -121,13 +126,13 @@ describe("resolveCadence", () => {
     test("single import statement", async () => {
       const CADENCE = `import "Foo"
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
       const expected = `import Foo from 0x1
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
@@ -147,14 +152,14 @@ pub fun main(): Address {
       const CADENCE = `import "Foo"
 import "Bar"
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
       const expected = `import Foo from 0x1
 import "Bar"
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
@@ -174,14 +179,14 @@ pub fun main(): Address {
       const CADENCE = `import "Foo"
 import "Bar"
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
       const expected = `import Foo from 0x1
 import Bar from 0x2
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
@@ -201,13 +206,13 @@ pub fun main(): Address {
     test("should prefix addresses with `0x` if not already present", async () => {
       const CADENCE = `import "Foo"
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 
       const expected = `import Foo from 0x1
 
-pub fun main(): Address {
+access(all) fun main(): Address {
   return "Foo"
 }`
 

--- a/packages/transport-grpc/src/send-execute-script.test.js
+++ b/packages/transport-grpc/src/send-execute-script.test.js
@@ -30,7 +30,9 @@ describe("Send Execute Script", () => {
     })
 
     let response = await sendExecuteScript(
-      await resolve(await build([script`pub fun main(): Int { return 123 }`])),
+      await resolve(
+        await build([script`access(all) fun main(): Int { return 123 }`])
+      ),
       {
         response: responseADT,
         Buffer,
@@ -71,7 +73,7 @@ describe("Send Execute Script", () => {
     const response = await sendExecuteScript(
       await resolve(
         await build([
-          script`pub fun main(): Int { return 123 }`,
+          script`access(all) fun main(): Int { return 123 }`,
           atBlockId("abc123"),
         ])
       ),
@@ -117,7 +119,7 @@ describe("Send Execute Script", () => {
     const response = await sendExecuteScript(
       await resolve(
         await build([
-          script`pub fun main(): Int { return 123 }`,
+          script`access(all) fun main(): Int { return 123 }`,
           atBlockHeight(123),
         ])
       ),

--- a/packages/transport-http/src/send-execute-script.test.js
+++ b/packages/transport-http/src/send-execute-script.test.js
@@ -22,7 +22,7 @@ describe("Send Execute Script", () => {
 
     httpRequestMock.mockReturnValue(returnedJSONCDC)
 
-    const cadence = "pub fun main(a: Int): Int { return a }"
+    const cadence = "access(all) fun main(a: Int): Int { return a }"
 
     let response = await sendExecuteScript(
       await resolve(
@@ -69,7 +69,7 @@ describe("Send Execute Script", () => {
 
     httpRequestMock.mockReturnValue(returnedJSONCDC)
 
-    const cadence = "pub fun main(): Int { return 123 }"
+    const cadence = "access(all) fun main(): Int { return 123 }"
 
     let response = await sendExecuteScript(
       await resolve(await build([script(cadence), atBlockId(123)])),
@@ -114,7 +114,7 @@ describe("Send Execute Script", () => {
 
     httpRequestMock.mockReturnValue(returnedJSONCDC)
 
-    const cadence = "pub fun main(): Int { return 123 }"
+    const cadence = "access(all) fun main(): Int { return 123 }"
 
     let response = await sendExecuteScript(
       await resolve(await build([script(cadence), atBlockHeight(123)])),

--- a/packages/transport-http/src/send-execute-script.test.js
+++ b/packages/transport-http/src/send-execute-script.test.js
@@ -51,7 +51,8 @@ describe("Send Execute Script", () => {
       path: "/v1/scripts?block_height=sealed",
       method: "POST",
       body: {
-        script: "cHViIGZ1biBtYWluKGE6IEludCk6IEludCB7IHJldHVybiBhIH0=",
+        script:
+          "YWNjZXNzKGFsbCkgZnVuIG1haW4oYTogSW50KTogSW50IHsgcmV0dXJuIGEgfQ==",
         arguments: ["eyJ0eXBlIjoiSW50IiwidmFsdWUiOiIxMjMifQ=="],
       },
     })
@@ -96,7 +97,7 @@ describe("Send Execute Script", () => {
       path: "/v1/scripts?block_id=123",
       method: "POST",
       body: {
-        script: "cHViIGZ1biBtYWluKCk6IEludCB7IHJldHVybiAxMjMgfQ==",
+        script: "YWNjZXNzKGFsbCkgZnVuIG1haW4oKTogSW50IHsgcmV0dXJuIDEyMyB9",
         arguments: [],
       },
     })
@@ -141,7 +142,7 @@ describe("Send Execute Script", () => {
       path: "/v1/scripts?block_height=123",
       method: "POST",
       body: {
-        script: "cHViIGZ1biBtYWluKCk6IEludCB7IHJldHVybiAxMjMgfQ==",
+        script: "YWNjZXNzKGFsbCkgZnVuIG1haW4oKTogSW50IHsgcmV0dXJuIDEyMyB9",
         arguments: [],
       },
     })


### PR DESCRIPTION
closes #1833 

Updates access modifiers to support Cadence 1.0.  There may be some other changes to FCLCrypto depending on how we go about migrating FCLCrypto and satisfying https://github.com/onflow/fcl-contracts/issues/18.  However this is a good pre-emptive change.