### PR TITLE
Remove client services from FCL-WC plugin

### DIFF
--- a/.changeset/red-dodos-march.md
+++ b/.changeset/red-dodos-march.md
@@ -1,0 +1,5 @@
+---
+"@onflow/fcl-wc": minor
+---
+
+Remove unnecessary client services from FCL-WC plugin

--- a/packages/fcl-wc/src/service.js
+++ b/packages/fcl-wc/src/service.js
@@ -1,14 +1,13 @@
 import {WalletConnectModal} from "@walletconnect/modal"
 import {invariant} from "@onflow/util-invariant"
 import {log, LEVELS} from "@onflow/util-logger"
-import {fetchFlowWallets, isMobile, CONFIGURED_NETWORK, isIOS} from "./utils"
+import {isMobile, CONFIGURED_NETWORK, isIOS} from "./utils"
 import {FLOW_METHODS, REQUEST_TYPES} from "./constants"
 
 export const makeServicePlugin = async (client, opts = {}) => ({
   name: "fcl-plugin-service-walletconnect",
   f_type: "ServicePlugin",
   type: "discovery-service",
-  services: await makeWcServices(opts),
   serviceStrategy: {method: "WC/RPC", exec: makeExec(client, opts)},
 })
 
@@ -211,8 +210,8 @@ async function connectWc({
 
   const projectId = client.opts.projectId
   const web3Modal = new WalletConnectModal({
-    projectId
-  });
+    projectId,
+  })
 
   try {
     const {uri, approval} = await client.connect({
@@ -270,32 +269,4 @@ async function connectWc({
     }
     web3Modal.closeModal()
   }
-}
-
-const makeBaseWalletConnectService = includeBaseWC => {
-  return {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "authn",
-    method: "WC/RPC",
-    uid: "https://walletconnect.com",
-    endpoint: "flow_authn",
-    optIn: !includeBaseWC,
-    provider: {
-      address: null,
-      name: "WalletConnect",
-      icon: "https://avatars.githubusercontent.com/u/37784886",
-      description: "WalletConnect Base Service",
-      website: "https://walletconnect.com",
-      color: null,
-      supportEmail: null,
-    },
-  }
-}
-
-async function makeWcServices({projectId, includeBaseWC, wallets}) {
-  const wcBaseService = makeBaseWalletConnectService(includeBaseWC)
-  const flowWcWalletServices = (await fetchFlowWallets(projectId)) ?? []
-  const injectedWalletServices = CONFIGURED_NETWORK !== "mainnet" ? wallets : []
-  return [wcBaseService, ...flowWcWalletServices, ...injectedWalletServices]
 }


### PR DESCRIPTION
closes #1871 

These were generally unused previously - the only caveat is the WalletConnect "base" service, which did get used by discovery.  However, this service should be the responsibility of FCL Discovery - IF we still want to show it

(I would argue that that any usage of the WalletConnect selection modal at all is just a shortcut, and ultimately it is the responsibility of FCL Discovery to list FCL wallets - as we do with "Flow Wallet" currently)