### PR TITLE
OPS -- Exclude transport-grpc from releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@onflow/transport-grpc"]
 }


### PR DESCRIPTION
Transport GRPC is deprecated.  This should not be part of releases anymore.