### PR TITLE
Fix broken changeset

### DIFF
--- a/.changeset/slow-lies-fix.md
+++ b/.changeset/slow-lies-fix.md
@@ -1,7 +1,6 @@
 ---
 "@onflow/fcl-react-native": patch
 "@onflow/util-encode-key": patch
-"@onflow/transport-grpc": patch
 "@onflow/transport-http": patch
 "@onflow/util-invariant": patch
 "@onflow/util-template": patch


### PR DESCRIPTION
There is a broken changeset file which causes a release to transport-grpc which has been deprecated.