### PR TITLE
Ignore unnecessary files for typedefs in npm package.

### DIFF
--- a/packages/typedefs/.npmignore
+++ b/packages/typedefs/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!types/**
+!package.json
+!README.md


### PR DESCRIPTION
Currently, after installation to `node_modules`, an error in tsconfig.json will be prompted. like `"../../tsconfig" not found`