### PR TITLE
Fix Testnet Chain ID

### DIFF
--- a/packages/fcl-ethereum-provider/src/accounts/account-manager.test.ts
+++ b/packages/fcl-ethereum-provider/src/accounts/account-manager.test.ts
@@ -127,7 +127,7 @@ describe("AccountManager", () => {
     await userMock.set!({addr: "0x1"} as CurrentUser)
 
     // Call getAndCreateAccounts. Since the COA already exists, it should just return it.
-    const accounts = await accountManager.getAndCreateAccounts(646)
+    const accounts = await accountManager.getAndCreateAccounts(545)
 
     expect(accounts).toEqual(["0x123"])
     // Should not have created a new COA
@@ -299,7 +299,7 @@ describe("send transaction", () => {
 
   test("send transaction testnet", async () => {
     // Set chainId to testnet
-    $mockChainId.next(646)
+    $mockChainId.next(545)
 
     const mockTxResult = {
       onceExecuted: jest.fn().mockResolvedValue({
@@ -328,7 +328,7 @@ describe("send transaction", () => {
       data: "0x1234",
       nonce: "0",
       gas: "0",
-      chainId: "646",
+      chainId: "545",
     }
 
     const result = await accountManager.sendTransaction(tx)
@@ -388,11 +388,11 @@ describe("send transaction", () => {
       data: "0x1234",
       nonce: "0",
       gas: "0",
-      chainId: "646",
+      chainId: "545",
     }
 
     await expect(accountManager.sendTransaction(tx)).rejects.toThrow(
-      `Chain ID does not match the current network. Expected: 747, Received: 646`
+      `Chain ID does not match the current network. Expected: 747, Received: 545`
     )
 
     expect(fcl.mutate).not.toHaveBeenCalled()

--- a/packages/fcl-ethereum-provider/src/constants.ts
+++ b/packages/fcl-ethereum-provider/src/constants.ts
@@ -9,7 +9,7 @@ export const FLOW_CHAINS = {
     publicRpcUrl: "https://access.mainnet.nodes.onflow.org",
   },
   [FlowNetwork.TESTNET]: {
-    eip155ChainId: 646,
+    eip155ChainId: 545,
     publicRpcUrl: "https://access.testnet.nodes.onflow.org",
   },
 }

--- a/packages/fcl-ethereum-provider/src/gateway/gateway.test.ts
+++ b/packages/fcl-ethereum-provider/src/gateway/gateway.test.ts
@@ -13,7 +13,7 @@ describe("gateway", () => {
   test("request should work for mainnet", async () => {
     const gateway = new Gateway({
       747: "https://example.com",
-      646: "https://example.com/testnet",
+      545: "https://example.com/testnet",
     })
 
     jest.mocked(JsonRpcProvider).mockImplementation(
@@ -51,7 +51,7 @@ describe("gateway", () => {
   test("request should work for testnet", async () => {
     const gateway = new Gateway({
       747: "https://example.com",
-      646: "https://example.com/testnet",
+      545: "https://example.com/testnet",
     })
 
     jest.mocked(JsonRpcProvider).mockImplementation(
@@ -66,7 +66,7 @@ describe("gateway", () => {
     const returnValue = await gateway.request({
       method: "eth_accounts",
       params: [],
-      chainId: 646,
+      chainId: 545,
     })
 
     // Check that the arguments are correct
@@ -89,7 +89,7 @@ describe("gateway", () => {
   test("subsequent requests should use the same provider", async () => {
     const gateway = new Gateway({
       747: "https://example.com",
-      646: "https://example.com/testnet",
+      545: "https://example.com/testnet",
     })
 
     jest.mocked(JsonRpcProvider).mockImplementation(
@@ -104,13 +104,13 @@ describe("gateway", () => {
     await gateway.request({
       method: "eth_accounts",
       params: [],
-      chainId: 646,
+      chainId: 545,
     })
 
     await gateway.request({
       method: "eth_accounts",
       params: [],
-      chainId: 646,
+      chainId: 545,
     })
 
     // Verify that the testnet provider was used
@@ -125,7 +125,7 @@ describe("gateway", () => {
   test("request should throw if chainId is not found", async () => {
     const gateway = new Gateway({
       747: "https://example.com",
-      646: "https://example.com/testnet",
+      545: "https://example.com/testnet",
     })
 
     await expect(
@@ -181,7 +181,7 @@ describe("gateway", () => {
     await gateway.request({
       method: "eth_accounts",
       params: [],
-      chainId: 646,
+      chainId: 545,
     })
 
     // Verify that the testnet provider was used

--- a/packages/fcl-ethereum-provider/src/network/network-manager.test.ts
+++ b/packages/fcl-ethereum-provider/src/network/network-manager.test.ts
@@ -36,7 +36,7 @@ describe("network manager", () => {
     const manager = new NetworkManager(config.mock)
     const chainId = await manager.getChainId()
 
-    expect(chainId).toBe(646)
+    expect(chainId).toBe(545)
   })
 
   test("getChainId should throw error on unknown network", async () => {

--- a/packages/fcl-ethereum-provider/src/rpc/rpc-processor.test.ts
+++ b/packages/fcl-ethereum-provider/src/rpc/rpc-processor.test.ts
@@ -51,7 +51,7 @@ describe("rpc processor", () => {
     )
 
     jest.mocked(gateway).request.mockResolvedValue("0x0")
-    networkManager.getChainId.mockResolvedValue(646)
+    networkManager.getChainId.mockResolvedValue(545)
 
     const response = await rpcProcessor.handleRequest({
       method: "eth_blockNumber",
@@ -64,7 +64,7 @@ describe("rpc processor", () => {
     expect(gateway.request).toHaveBeenCalledWith({
       method: "eth_blockNumber",
       params: [],
-      chainId: 646,
+      chainId: 545,
     })
   })
 


### PR DESCRIPTION
Currently the chain ID is erroneously set to `646`, it should be `545`.