### PR TITLE
Fix failed transaction tracking

### DIFF
--- a/packages/fcl-ethereum-provider/src/cadence.ts
+++ b/packages/fcl-ethereum-provider/src/cadence.ts
@@ -52,7 +52,6 @@ transaction(evmContractAddressHex: String, calldata: String, gasLimit: UInt64, v
             gasLimit: gasLimit,
             value: valueBalance
         )
-        assert(callResult.status == EVM.Status.successful, message: "Call failed")
     }
 }`
 


### PR DESCRIPTION
Currently, we revert Cadence transactions where EVM transactions have failed.  We should not do this since this prevents these results from being reported to GW, block explorers, etc.