### PR TITLE
Revert "Version Packages (cross-vm)"

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -28,8 +28,5 @@
     "@onflow/util-template": "1.2.3",
     "@onflow/util-uid": "1.2.3"
   },
-  "changesets": [
-    "chilled-wombats-reply",
-    "shaggy-carpets-eat"
-  ]
+  "changesets": []
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/estree": "^1.0.6",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages/fcl-bundle/CHANGELOG.md
+++ b/packages/fcl-bundle/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @onflow/fcl-bundle
 
-## 1.7.0-cross-vm.0
-
-### Minor Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/fcl-bundle/package.json
+++ b/packages/fcl-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-bundle",
-  "version": "1.7.0-cross-vm.0",
+  "version": "1.6.0",
   "description": "FCL Bundler Tool",
   "license": "Apache-2.0",
   "author": "Flow Foundation",

--- a/packages/fcl-core/CHANGELOG.md
+++ b/packages/fcl-core/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @onflow/fcl
 
-## 1.14.0-cross-vm.0
-
-### Minor Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-### Patch Changes
-
-- [#2065](https://github.com/onflow/fcl-js/pull/2065) [`3fccbef7bbf985f19d9a9bae2638e538f126f754`](https://github.com/onflow/fcl-js/commit/3fccbef7bbf985f19d9a9bae2638e538f126f754) Thanks [@jribbink](https://github.com/jribbink)! - Fix args type for `fcl.query` & `fcl.mutate`
-
 ## 1.13.4
 
 ### Patch Changes

--- a/packages/fcl-core/package.json
+++ b/packages/fcl-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-core",
-  "version": "1.14.0-cross-vm.0",
+  "version": "1.13.4",
   "description": "Flow Client Library",
   "license": "Apache-2.0",
   "author": "Flow Foundation",
@@ -19,7 +19,7 @@
     }
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "1.4.0",
     "@types/estree": "^1.0.6",
     "@types/jest": "^29.5.13",

--- a/packages/fcl-ethereum-provider/CHANGELOG.md
+++ b/packages/fcl-ethereum-provider/CHANGELOG.md
@@ -1,11 +1,1 @@
 # @onflow/fcl-ethereum-provider
-
-## 1.0.0-cross-vm.0
-
-### Patch Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-- Updated dependencies [[`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl-wc@6.0.0-cross-vm.0
-  - @onflow/fcl@1.14.0-cross-vm.0

--- a/packages/fcl-ethereum-provider/package.json
+++ b/packages/fcl-ethereum-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-ethereum-provider",
-  "version": "1.0.0-cross-vm.0",
+  "version": "0.0.0",
   "description": "Ethereum provider for FCL-compatible wallets",
   "license": "Apache-2.0",
   "author": "Dapper Labs <dev@dapperlabs.com>",
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "^1.4.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -40,7 +40,7 @@
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/hash": "^5.7.0",
     "@noble/hashes": "^1.7.1",
-    "@onflow/fcl-wc": "^6.0.0-cross-vm.0",
+    "@onflow/fcl-wc": "^5.5.4",
     "@onflow/rlp": "^1.2.3",
     "@walletconnect/ethereum-provider": "^2.18.0",
     "@walletconnect/jsonrpc-http-connection": "^1.0.8",
@@ -50,6 +50,6 @@
     "@walletconnect/utils": "^2.18.0"
   },
   "peerDependencies": {
-    "@onflow/fcl": "^1.14.0-cross-vm.0"
+    "@onflow/fcl": "^1.13.4"
   }
 }

--- a/packages/fcl-rainbowkit-adapter/CHANGELOG.md
+++ b/packages/fcl-rainbowkit-adapter/CHANGELOG.md
@@ -1,12 +1,1 @@
 # @onflow/fcl-ethereum-provider
-
-## 1.0.0-cross-vm.0
-
-### Patch Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-- Updated dependencies [[`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl@1.14.0-cross-vm.0
-  - @onflow/fcl-ethereum-provider@1.0.0-cross-vm.0
-  - @onflow/fcl-wagmi-adapter@1.0.0-cross-vm.0

--- a/packages/fcl-rainbowkit-adapter/package.json
+++ b/packages/fcl-rainbowkit-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-rainbowkit-adapter",
-  "version": "1.0.0-cross-vm.0",
+  "version": "0.0.0",
   "description": "Rainbowkit adapter for FCL-compatible wallets",
   "license": "Apache-2.0",
   "author": "Dapper Labs <dev@dapperlabs.com>",
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "^1.4.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -39,8 +39,8 @@
     "@babel/runtime": "^7.25.7",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/hash": "^5.7.0",
-    "@onflow/fcl-ethereum-provider": "^1.0.0-cross-vm.0",
-    "@onflow/fcl-wagmi-adapter": "^1.0.0-cross-vm.0",
+    "@onflow/fcl-ethereum-provider": "^0.0.0",
+    "@onflow/fcl-wagmi-adapter": "^0.0.0",
     "@onflow/rlp": "^1.2.3",
     "@wagmi/core": "^2.16.3",
     "@walletconnect/jsonrpc-http-connection": "^1.0.8",
@@ -50,7 +50,7 @@
     "wagmi": "^2.14.11"
   },
   "peerDependencies": {
-    "@onflow/fcl": "^1.14.0-cross-vm.0",
+    "@onflow/fcl": "^1.13.4",
     "@rainbow-me/rainbowkit": "^2.2.3"
   }
 }

--- a/packages/fcl-react-native/CHANGELOG.md
+++ b/packages/fcl-react-native/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @onflow/fcl-react-native
 
-## 1.9.12-cross-vm.0
-
-### Patch Changes
-
-- Updated dependencies [[`3fccbef7bbf985f19d9a9bae2638e538f126f754`](https://github.com/onflow/fcl-js/commit/3fccbef7bbf985f19d9a9bae2638e538f126f754), [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl-core@1.14.0-cross-vm.0
-
 ## 1.9.11
 
 ### Patch Changes

--- a/packages/fcl-react-native/package.json
+++ b/packages/fcl-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-react-native",
-  "version": "1.9.12-cross-vm.0",
+  "version": "1.9.11",
   "description": "Flow Client Library",
   "license": "Apache-2.0",
   "author": "Flow Foundation",
@@ -19,7 +19,7 @@
     }
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "1.4.0",
     "@types/estree": "^1.0.6",
     "@types/node": "^18.19.57",
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.25.7",
     "@onflow/config": "1.5.1",
-    "@onflow/fcl-core": "1.14.0-cross-vm.0",
+    "@onflow/fcl-core": "1.13.4",
     "@onflow/interaction": "0.0.11",
     "@onflow/rlp": "1.2.3",
     "@onflow/sdk": "1.5.6",

--- a/packages/fcl-wagmi-adapter/CHANGELOG.md
+++ b/packages/fcl-wagmi-adapter/CHANGELOG.md
@@ -1,11 +1,1 @@
 # @onflow/fcl-ethereum-provider
-
-## 1.0.0-cross-vm.0
-
-### Patch Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-- Updated dependencies [[`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl@1.14.0-cross-vm.0
-  - @onflow/fcl-ethereum-provider@1.0.0-cross-vm.0

--- a/packages/fcl-wagmi-adapter/package.json
+++ b/packages/fcl-wagmi-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-wagmi-adapter",
-  "version": "1.0.0-cross-vm.0",
+  "version": "0.0.0",
   "description": "Wagmi adapter for FCL-compatible wallets",
   "license": "Apache-2.0",
   "author": "Dapper Labs <dev@dapperlabs.com>",
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "^1.4.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -39,7 +39,7 @@
     "@babel/runtime": "^7.25.7",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/hash": "^5.7.0",
-    "@onflow/fcl-ethereum-provider": "^1.0.0-cross-vm.0",
+    "@onflow/fcl-ethereum-provider": "^0.0.0",
     "@onflow/rlp": "^1.2.3",
     "@walletconnect/jsonrpc-http-connection": "^1.0.8",
     "@walletconnect/jsonrpc-provider": "^1.0.14",
@@ -50,7 +50,7 @@
     "viem": "^2.22.21"
   },
   "peerDependencies": {
-    "@onflow/fcl": "^1.14.0-cross-vm.0",
+    "@onflow/fcl": "^1.13.4",
     "@wagmi/core": "^2.16.3"
   }
 }

--- a/packages/fcl-wc/CHANGELOG.md
+++ b/packages/fcl-wc/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @onflow/fcl-wc
 
-## 6.0.0-cross-vm.0
-
-### Major Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-### Patch Changes
-
-- Updated dependencies [[`3fccbef7bbf985f19d9a9bae2638e538f126f754`](https://github.com/onflow/fcl-js/commit/3fccbef7bbf985f19d9a9bae2638e538f126f754), [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl-core@1.14.0-cross-vm.0
-
 ## 5.5.4
 
 ### Patch Changes

--- a/packages/fcl-wc/package.json
+++ b/packages/fcl-wc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl-wc",
-  "version": "6.0.0-cross-vm.0",
+  "version": "5.5.4",
   "description": "WalletConnect adapter for FCL",
   "license": "Apache-2.0",
   "author": "Flow Foundation",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "^1.4.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
@@ -55,6 +55,6 @@
     "tailwindcss": "^3.4.14"
   },
   "peerDependencies": {
-    "@onflow/fcl-core": "1.14.0-cross-vm.0"
+    "@onflow/fcl-core": "1.13.4"
   }
 }

--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @onflow/fcl
 
-## 1.14.0-cross-vm.0
-
-### Minor Changes
-
-- [#2154](https://github.com/onflow/fcl-js/pull/2154) [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724) Thanks [@jribbink](https://github.com/jribbink)! - FCL Ethereum Provider & Cross VM Support Alpha Release
-
-### Patch Changes
-
-- Updated dependencies [[`3fccbef7bbf985f19d9a9bae2638e538f126f754`](https://github.com/onflow/fcl-js/commit/3fccbef7bbf985f19d9a9bae2638e538f126f754), [`e8f5585cd029716940c55e72fc53dc9563fec724`](https://github.com/onflow/fcl-js/commit/e8f5585cd029716940c55e72fc53dc9563fec724)]:
-  - @onflow/fcl-core@1.14.0-cross-vm.0
-  - @onflow/fcl-wc@6.0.0-cross-vm.0
-
 ## 1.13.4
 
 ### Patch Changes

--- a/packages/fcl/package.json
+++ b/packages/fcl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/fcl",
-  "version": "1.14.0-cross-vm.0",
+  "version": "1.13.4",
   "description": "Flow Client Library",
   "license": "Apache-2.0",
   "author": "Flow Foundation",
@@ -19,7 +19,7 @@
     }
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/typedefs": "1.4.0",
     "@types/estree": "^1.0.6",
     "@types/jest": "^29.5.13",
@@ -49,8 +49,8 @@
   "dependencies": {
     "@babel/runtime": "^7.25.7",
     "@onflow/config": "1.5.1",
-    "@onflow/fcl-core": "1.14.0-cross-vm.0",
-    "@onflow/fcl-wc": "6.0.0-cross-vm.0",
+    "@onflow/fcl-core": "1.13.4",
+    "@onflow/fcl-wc": "5.5.4",
     "@onflow/interaction": "0.0.11",
     "@onflow/rlp": "1.2.3",
     "@onflow/sdk": "1.5.6",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,7 +18,7 @@
     }
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/uuid": "^9.0.8",
     "eslint": "^8.57.1",
     "eslint-plugin-jsdoc": "^46.10.1",

--- a/packages/transport-grpc/package.json
+++ b/packages/transport-grpc/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/onflow/fcl-js/issues"
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/sdk": "1.5.6",
     "jest": "^29.7.0"
   },

--- a/packages/transport-http/package.json
+++ b/packages/transport-http/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/onflow/fcl-js/issues"
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/rlp": "1.2.3",
     "@onflow/sdk": "1.5.6",
     "@onflow/types": "1.4.1",

--- a/packages/typedefs/package.json
+++ b/packages/typedefs/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/onflow/fcl-js/issues"
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/node": "^18.19.57",
     "eslint": "^8.57.1",
     "eslint-plugin-jsdoc": "^46.10.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/util-actor/package.json
+++ b/packages/util-actor/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/util-address/package.json
+++ b/packages/util-address/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/types": "1.4.1",
     "@types/jest": "^29.5.13",
     "@types/node": "^18.19.57",

--- a/packages/util-encode-key/package.json
+++ b/packages/util-encode-key/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/types": "1.4.1",
     "@types/jest": "^29.5.13",
     "@types/node": "^18.19.57",

--- a/packages/util-invariant/package.json
+++ b/packages/util-invariant/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@onflow/types": "1.4.1",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages/util-logger/package.json
+++ b/packages/util-logger/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/util-rpc/package.json
+++ b/packages/util-rpc/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/util-semver/package.json
+++ b/packages/util-semver/package.json
@@ -14,7 +14,7 @@
     "start": "fcl-bundle --watch"
   },
   "devDependencies": {
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "jest": "^29.7.0"
   },
   "dependencies": {

--- a/packages/util-template/package.json
+++ b/packages/util-template/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/util-uid/package.json
+++ b/packages/util-uid/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.25.7",
-    "@onflow/fcl-bundle": "1.7.0-cross-vm.0",
+    "@onflow/fcl-bundle": "1.6.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",


### PR DESCRIPTION
Reverts onflow/fcl-js#2155

There was an issue with the changesets bot for the alpha release and I need to edit the version packages PR to correct.