### PR TITLE
Fix regression in `fcl.account` at latest block

### DIFF
--- a/.changeset/loud-suits-clean.md
+++ b/.changeset/loud-suits-clean.md
@@ -1,0 +1,8 @@
+---
+"@onflow/fcl": patch
+"@onflow/fcl-core": patch
+"@onflow/fcl-react-native": patch
+"@onflow/sdk": patch
+---
+
+Fix regression in `account` query at latest block

--- a/packages/sdk/src/account/account.ts
+++ b/packages/sdk/src/account/account.ts
@@ -5,22 +5,27 @@ import {getAccount} from "../build/build-get-account.js"
 import {invariant} from "@onflow/util-invariant"
 import {decodeResponse as decode} from "../decode/decode.js"
 import {send} from "../send/send.js"
+import type {Account} from "@onflow/typedefs"
 
 /**
- * @typedef {import("@onflow/typedefs").Account} Account
+ * @description Returns the details of an account from their public address
+ * @param address - Address of the account
+ * @param queryOptions - Query parameters
+ * @param queryOptions.height - Block height to query
+ * @param queryOptions.id - Block ID to query
+ * @param queryOptions.isSealed - Block finality
+ * @param opts - Optional parameters
+ * @returns A promise that resolves to an account response
  */
-
-/**
- * @description  Returns the details of an account from their public address
- * @param {string} address - Address of the account
- * @param {object} [queryOptions] - Query parameters
- * @param {number} [queryOptions.height] - Block height to query
- * @param {string} [queryOptions.id] - Block ID to query
- * @param {boolean} [queryOptions.isSealed] - Block finality
- * @param {object} [opts] - Optional parameters
- * @returns {Promise<Account>} - A promise that resolves to an account response
- */
-export async function account(address, {height, id, isSealed} = {}, opts) {
+export async function account(
+  address: string,
+  {
+    height,
+    id,
+    isSealed,
+  }: {height?: number; id?: string; isSealed?: boolean} = {},
+  opts?: object
+): Promise<Account> {
   invariant(
     !((id && height) || (id && isSealed) || (height && isSealed)),
     `Method: account -- Only one of the following parameters can be provided: id, height, isSealed`
@@ -38,7 +43,7 @@ export async function account(address, {height, id, isSealed} = {}, opts) {
 
   // Get account by latest block
   return await send(
-    [getAccount(address), opts.isSealed != null && atLatestBlock(isSealed)],
+    [getAccount(address), isSealed != null && atLatestBlock(isSealed)],
     opts
   ).then(decode)
 }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -45,7 +45,7 @@ export {template as cadence} from "@onflow/util-template"
 export {template as cdc} from "@onflow/util-template"
 
 // Helpers
-export {account} from "./account/account.js"
+export {account} from "./account/account"
 export {block} from "./block/block.js"
 export {nodeVersionInfo} from "./node-version-info/node-version-info"
 

--- a/packages/sdk/src/send/send.js
+++ b/packages/sdk/src/send/send.js
@@ -9,7 +9,7 @@ import {resolve as defaultResolve} from "../resolve/resolve.js"
 
 /**
  * @description - Sends arbitrary scripts, transactions, and requests to Flow
- * @param {Array.<Function> | Function} args - An array of functions that take interaction and return interaction
+ * @param {Array.<Function | false> | Function | false} args - An array of functions that take interaction and return interaction
  * @param {object} opts - Optional parameters
  * @returns {Promise<*>} - A promise that resolves to a response
  */


### PR DESCRIPTION
Closes #2244 

The bug fix is the change from `opts.isSealed` to `isSealed`.  I've also switched the file over to typescript to prevent this issue in the future.