### PR TITLE
Add enabled flag to query hook

### DIFF
--- a/packages/kit/src/hooks/useFlowQuery.test.ts
+++ b/packages/kit/src/hooks/useFlowQuery.test.ts
@@ -53,8 +53,6 @@ describe("useFlowQuery", () => {
     const queryMock = jest.mocked(fcl.query)
     queryMock.mockResolvedValueOnce(expectedResult)
 
-    let hookResult: any
-
     await act(async () => {
       const {result} = renderHook(
         () => useFlowQuery({cadence: cadenceScript, enabled: false}),

--- a/packages/kit/src/hooks/useFlowQuery.test.ts
+++ b/packages/kit/src/hooks/useFlowQuery.test.ts
@@ -47,6 +47,27 @@ describe("useFlowQuery", () => {
     })
   })
 
+  test("does not fetch data when enabled is false", async () => {
+    const cadenceScript = "access(all) fun main(): Int { return 42 }"
+    const expectedResult = 42
+    const queryMock = jest.mocked(fcl.query)
+    queryMock.mockResolvedValueOnce(expectedResult)
+
+    let hookResult: any
+
+    await act(async () => {
+      const {result} = renderHook(
+        () => useFlowQuery({cadence: cadenceScript, enabled: false}),
+        {
+          wrapper: FlowProvider,
+        }
+      )
+      hookResult = result
+    })
+
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
   test("handles error from fcl.query", async () => {
     const cadenceScript = "access(all) fun main(): Int { return 42 }"
     const testError = new Error("Query failed")

--- a/packages/kit/src/hooks/useFlowQuery.test.ts
+++ b/packages/kit/src/hooks/useFlowQuery.test.ts
@@ -49,21 +49,16 @@ describe("useFlowQuery", () => {
 
   test("does not fetch data when enabled is false", async () => {
     const cadenceScript = "access(all) fun main(): Int { return 42 }"
-    const expectedResult = 42
     const queryMock = jest.mocked(fcl.query)
-    queryMock.mockResolvedValueOnce(expectedResult)
 
-    await act(async () => {
-      const {result} = renderHook(
-        () => useFlowQuery({cadence: cadenceScript, enabled: false}),
-        {
-          wrapper: FlowProvider,
-        }
-      )
-      hookResult = result
+    renderHook(() => useFlowQuery({cadence: cadenceScript, enabled: false}), {
+      wrapper: FlowProvider,
     })
 
-    expect(queryMock).not.toHaveBeenCalled()
+    // wait a little to ensure fcl.query isn't called
+    await waitFor(() => {
+      expect(queryMock).not.toHaveBeenCalled()
+    })
   })
 
   test("handles error from fcl.query", async () => {

--- a/packages/kit/src/hooks/useFlowQuery.ts
+++ b/packages/kit/src/hooks/useFlowQuery.ts
@@ -6,6 +6,7 @@ import {useFlowQueryClient} from "../provider/FlowQueryClient"
 interface FlowQueryArgs {
   cadence: string
   args?: (arg: typeof fcl.arg, t: typeof fcl.t) => unknown[]
+  enabled?: boolean
 }
 
 /**
@@ -21,6 +22,7 @@ interface FlowQueryArgs {
 export function useFlowQuery({
   cadence,
   args,
+  enabled = true,
 }: FlowQueryArgs): UseQueryResult<unknown, Error> {
   const queryClient = useFlowQueryClient()
 
@@ -33,7 +35,7 @@ export function useFlowQuery({
     {
       queryKey: ["flowQuery", cadence, args],
       queryFn: fetchQuery,
-      enabled: Boolean(cadence),
+      enabled: enabled,
       retry: false,
       initialData: null,
     },


### PR DESCRIPTION
https://github.com/onflow/fcl-js/issues/2262

```
const { data, isLoading, error, refetch } = useFlowQuery({
  enabled: !!user?.addr, // Only enable query when user.addr is truthy
  cadence: `
    pub fun main(userAddr: Address): Int {
      return 42
    }
  `,
  args: (arg, t) => [arg(user!.addr, t.Address)],
});
```