### PR TITLE
Fix Typos in Documentation Files

### DIFF
--- a/packages/fcl-core/src/wallet-provider-spec/authorization-function.md
+++ b/packages/fcl-core/src/wallet-provider-spec/authorization-function.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-An Authorization Function is a function which enables the JS-SDK and FCL to know which Flow account fulfills which signatory role in a transaction and how to recieve a signature on behalf of the supplied account.
+An Authorization Function is a function which enables the JS-SDK and FCL to know which Flow account fulfills which signatory role in a transaction and how to receive a signature on behalf of the supplied account.
 
 ## How to Use an Authorization Function
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -403,7 +403,7 @@ sdk.build([
 
 # Exist but not supported
 
-The following, while technically possible, are impracticle. We strongly recommend not using them as arguments for transactions or scripts.
+The following, while technically possible, are impractical. We strongly recommend not using them as arguments for transactions or scripts.
 
 ### Void
 


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in two documentation files:
- In `authorization-function.md`, the word "recieve" was corrected to "receive".
- In `README.md`, the word "impracticle" was corrected to "impractical".

These changes improve the clarity and professionalism of the documentation. No functional code changes are included.
