### PR TITLE
Fix Documentation Typos

### DIFF
--- a/packages/fcl-core/src/wallet-provider-spec/draft.md
+++ b/packages/fcl-core/src/wallet-provider-spec/draft.md
@@ -65,7 +65,7 @@ to communicate with various services like wallets.
 
 `fcl.authenticate()` is triggered. It looks up the **Challenge Handshake Url** with
 `config().get("challenge.handshake")`. FCL will render an iframe using the **Challenge
-Handshake Url** at the src, also passing in a couple query paramaters.
+Handshake Url** at the src, also passing in a couple query parameters.
 
 > During development (and on mainnet) FCL can be configured to use the wallet directly by
 > setting the **Challenge Handshake Url** to the wallet providers **Authentication Endpoint**
@@ -226,7 +226,7 @@ type Handshake {
   hks and code work together to enable FCL to discover
   how to configure itself for the Current User. If these
   are both supplied an http get request will be made
-  to the hks url with the code as a query paramater.
+  to the hks url with the code as a query parameter.
   It should return an array of services. These services
   will be chosen over those returned directly in the
   handshake

--- a/packages/fcl-core/src/wallet-provider-spec/provable-authn.md
+++ b/packages/fcl-core/src/wallet-provider-spec/provable-authn.md
@@ -52,7 +52,7 @@ import {WalletUtils} from "@onflow/fcl"
 const message = WalletUtils.encodeAccountProof(
   appIdentifier, // A human readable string to identify your application during signing
   address,       // Flow address of the user authenticating
-  nonce,         // minimum 32-btye nonce
+  nonce,         // minimum 32-byte nonce
 )
 
 sign(privateKey, message)

--- a/packages/fcl-core/src/wallet-provider-spec/user-signature.md
+++ b/packages/fcl-core/src/wallet-provider-spec/user-signature.md
@@ -11,7 +11,7 @@
 
 **Personally sign data via FCL Compatible Wallets**
 
-**FCL** now incldues **`signUserMessage()`** which allows for the sending of unencrypted message data to a connected wallet provider or service to be signed with a user's private key. 
+**FCL** now includes **`signUserMessage()`** which allows for the sending of unencrypted message data to a connected wallet provider or service to be signed with a user's private key. 
 
 An application or service can verify a signature against a user's public key on the **Flow Blockchain**, providing proof a user controls the account's private key.   
 

--- a/packages/util-template/README.md
+++ b/packages/util-template/README.md
@@ -66,7 +66,7 @@ y: Y
 
 ## Examples
 
-**Role your own graphql libary**
+**Role your own graphql library**
 
 ```javascript
 // gql.js
@@ -174,7 +174,7 @@ assert(rawr, {
       log("msg: woot woot im a boot")
     }
   `,
-  descrition: `
+  description: `
     the message: woot woot im a boot
   `,
 })


### PR DESCRIPTION
Fixes several typos in documentation:

- `draft.md`: "paramaters" → "parameters" , "paramater" → "parameter"
- `provable-authn.md`: "32-btye" → "32-byte"
- `user-signature.md`: "incldues" → "includes"
- `util-template/README.md`: "libary" → "library", "descrition" → "description"

These corrections improve documentation clarity and professionalism for wallet provider specs and utility templates.