### PR TITLE
chore: Fix typos

### DIFF
--- a/packages/fcl-wagmi-adapter/src/fcl-connector.ts
+++ b/packages/fcl-wagmi-adapter/src/fcl-connector.ts
@@ -185,7 +185,7 @@ export function fclWagmiAdapter(params: FclWagmiAdapterParams) {
       }
       provider.on("disconnect", disconnect)
     },
-    // TODO: waht to do with error?
+    // TODO: what to do with error?
     async onDisconnect(error) {
       const provider = await this.getProvider()
 

--- a/packages/protobuf/src/proto/flow/entities/block_execution_data.proto
+++ b/packages/protobuf/src/proto/flow/entities/block_execution_data.proto
@@ -39,7 +39,7 @@ message ChunkExecutionData {
 
   // Transaction results produced by executing the collection.
   //
-  // Note: these are not the same type of results returned by other RPCs. These results are sepcific
+  // Note: these are not the same type of results returned by other RPCs. These results are specific
   // to execution data. The most notable difference is they only include a boolean value to indicate
   // whether or not an error was encountered during execution, not the error itself.
   repeated ExecutionDataTransactionResult transaction_results = 4;

--- a/packages/protobuf/src/proto/flow/executiondata/executiondata.proto
+++ b/packages/protobuf/src/proto/flow/executiondata/executiondata.proto
@@ -48,7 +48,7 @@ service ExecutionDataAPI {
   // all events are returned.
   //
   // Responses are returned for each block containing at least one event that
-  // matches the filter. Additionally, heatbeat responses
+  // matches the filter. Additionally, heartbeat responses
   // (SubscribeEventsResponse with no events) are returned periodically to allow
   // clients to track which blocks were searched. Clients can use this
   // information to determine which block to start from when reconnecting.

--- a/packages/util-encode-key/README.md
+++ b/packages/util-encode-key/README.md
@@ -16,7 +16,7 @@ const PUBLIC_KEY = "0bfcd8790c3ce88f3fac9d4bd23514f48bf0cdd1f6c3c8bdf87b11489b1b
 const ENCODED_KEY = encodeKey(
   PLUBLIC_KEY, // The key to encode (DER Hex)
   ECDSA_P256,  // The curve Flow needs to use with your key [ECDSA_P256|ECDSA_secp256k1]
-  SHA3_256,    // The hashing algorythm Flow needs to use with your key [SHA2_256|SHA3_256]
+  SHA3_256,    // The hashing algorithm Flow needs to use with your key [SHA2_256|SHA3_256]
   1000         // The weight you want this key to have [Range: 0..1000]
 )
 

--- a/packages/util-encode-key/src/index.ts
+++ b/packages/util-encode-key/src/index.ts
@@ -17,7 +17,7 @@ const VALID_HASHINGS = new Set([SHA2_256, SHA3_256])
  * Encodes a key into a hex string
  * @param key - The key to encode (DER Hex)
  * @param curve - The curve Flow needs to use with your key [ECDSA_P256|ECDSA_secp256k1]
- * @param hash - The hashing algorythm Flow needs to use with your key [SHA2_256|SHA3_256]
+ * @param hash - The hashing algorithm Flow needs to use with your key [SHA2_256|SHA3_256]
  * @param weight - The weight you want this key to have [Range: 0..1000]
  * @returns The encoded key
  * @throws {Error} - Throws if the key is not a string


### PR DESCRIPTION
Correct spelling errors:
  - "waht" → "what" 
  - "sepcific" → "specific",
  - "heatbeat" → "heartbeat" 
  - "algorythm" → "algorithm" 