### PR TITLE
docs: flag pre-Cadence 1.0 syntax in fcl.mutate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ const result = await fcl.query({
 console.log(result); // 13
 ```
 - *Mutate the chain*: Send arbitrary transactions with your own signatures or via a user's wallet to perform state changes on chain.
+
+> **Note:** The Cadence snippet below uses pre-1.0 syntax (`AuthAccount`, `account.borrow`, private paths). Cadence 1.0 replaced these with `auth(...) &Account`, `account.storage.borrow`, and storage-only paths. This example has not yet been updated — refer to the [Cadence migration guide](https://cadence-lang.org/docs/cadence-migration-guide) when writing new transactions.
+
 ```js
 import * as fcl from "@onflow/fcl";
 // in the browser, FCL will automatically connect to the user's wallet to request signatures to run the transaction


### PR DESCRIPTION
## Summary

The \`fcl.mutate\` code snippet in the README (lines 125–133) uses pre-Cadence 1.0 syntax that no longer compiles against current Cadence:

- \`prepare(account: AuthAccount)\` — \`AuthAccount\` was removed in 1.0, replaced with \`auth(...) &Account\`
- \`account.borrow<...>(from: ...)\` — borrow moved to \`account.storage.borrow\`
- \`Profile.privatePath\` — private paths were removed; storage is the only valid path domain

This PR only adds a \`> **Note:**\` callout above the code block pointing readers to the [Cadence migration guide](https://cadence-lang.org/docs/cadence-migration-guide). It does **not** rewrite the snippet itself, because writing a correct 1.0 replacement requires knowing the current Profile demo contract's storage path (which may have changed).

A follow-up PR can replace the snippet with a current working example once the Profile demo contract's API is confirmed.

## Test plan

- [x] Note renders above the code block on GitHub
- [x] Existing code block unchanged