### PR TITLE
Fix typedefs link in FCL README

### DIFF
--- a/packages/fcl/README.md
+++ b/packages/fcl/README.md
@@ -152,7 +152,7 @@ const newUser: CurrentUser = {
 }
 ```
 
-For all type definitions available, see [this file](../typedefs/src/index.ts)
+For all type definitions available, see [the typedefs package source](https://github.com/onflow/fcl-js/blob/master/packages/typedefs/src/index.ts)
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Fixes the broken typedefs link in `packages/fcl/README.md` by replacing the relative package link with a stable GitHub URL to the typedefs source file.

The previous link points to `../typedefs/src/index.ts`, which can break when the package README is rendered outside the monorepo context. The new link resolves directly to the source file in this repository.

## Related issue

Fixes #2235

## Testing

```bash
git diff --check -- packages/fcl/README.md
```

Manual verification: confirmed `packages/typedefs/src/index.ts` exists in the repository and the new URL targets that file.

